### PR TITLE
Support grant type refresh_token

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -8,6 +8,7 @@ var auth = require('./auth');
 var instance = require('./instance');
 var console = require('./log');
 var dwjson = require('./dwjson').init();
+var ocapi = require('./ocapi');
 
 const API_HOST_DEFAULT = 'admin.us01.dx.commercecloud.salesforce.com';
 const API_HOST = getAPIHost();
@@ -89,69 +90,31 @@ function captureCommonErrors(err, response, callback) {
 }
 
 /**
- * Contructs the http request options and ensure shared request headers across requests, such as authentication.
- *
- * @param {String} path
- * @param {String} token
- * @param {String} method
- * @return {Object} the request options
- */
-function getOptions(path, token, method) {
-    var opts = {
-        uri: 'https://' + path,
-        auth: {
-            bearer: ( token ? token : null )
-        },
-        strictSSL: false,
-        method: method,
-        json: true
-    };
-    return opts;
-}
-
-/**
  * Retrieves all realms and returns them as array.
  *
  * @param {Function} callback the callback to execute, the error and the list of realms are available as arguments to the callback function
  */
 function getRealms(callback) {
-    // build the request options
-    var options = getOptions(API_BASE + '/me', auth.getToken(), 'GET');
-
-    // do the request
-    request(options, function (err, res, body) {
-        var errback = captureCommonErrors(err, res);
-        if ( errback ) {
-            callback(errback, []);
-            return;
-        } else if ( err ) {
+    ocapi.retryableCall('GET', API_BASE + '/me', function(err, res) {
+        if ( err ) {
             callback(new Error(util.format('Getting realms failed: %s', err)), []);
-            return;
         } else if ( res.statusCode >= 400 ) {
             callback(new Error(util.format('Getting realms failed: %s', res.statusCode)));
-            return;
+        } else {
+            callback(undefined, res.body['data']['realms']);
         }
-        callback(undefined, body['data']['realms']);
     });
 }
 
 /**
- * Retrieves detals of a realm.
+ * Retrieves details of a realm.
  *
  * @param {String} realmID the id of the realm
  * @param {Function} callback the callback to execute, the error and the realm are available as arguments to the callback function
  */
 function getRealm(realmID, callback) {
-    // build the request options
-    var options = getOptions(API_BASE + '/realms/' + realmID + '?expand=configuration,usage', auth.getToken(), 'GET');
-
-    // do the request
-    request(options, function (err, res, body) {
-        var errback = captureCommonErrors(err, res);
-        if ( errback ) {
-            callback(errback);
-            return;
-        } else if ( err ) {
+    ocapi.retryableCall('GET', API_BASE + '/realms/' + realmID + '?expand=configuration,usage', function(err, res) {
+        if ( err ) {
             callback(new Error(util.format('Getting realm failed: %s', err)), []);
             return;
         } else if ( res.statusCode >= 400 ) {
@@ -172,7 +135,7 @@ function getRealm(realmID, callback) {
  */
 function updateRealm(realmID, maxSandboxTTL, defaultSandboxTTL, callback) {
     // build the request options
-    var options = getOptions(API_BASE + '/realms/' + realmID + '/configuration', auth.getToken(), 'PATCH');
+    var options = ocapi.getOptions('PATCH', API_BASE + '/realms/' + realmID + '/configuration');
 
     // the payload
     options['body'] = { sandbox : { sandboxTTL : {} } };
@@ -184,8 +147,7 @@ function updateRealm(realmID, maxSandboxTTL, defaultSandboxTTL, callback) {
         options['body']['sandbox']['sandboxTTL']['defaultValue'] = defaultSandboxTTL.toFixed();
     }
 
-    // do the request
-    request.patch(options, function (err, res, body) {
+    ocapi.retryableCall('PATCH', options, function(err, res) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
@@ -204,24 +166,16 @@ function updateRealm(realmID, maxSandboxTTL, defaultSandboxTTL, callback) {
  * @param {Function} callback the callback to execute, the error and the list of sandboxes are available as arguments to the callback function
  */
 function getAllSandboxes(callback) {
-    // build the request options
-    var options = getOptions(API_SANDBOXES, auth.getToken(), 'GET');
-
-    // do the request
-    request(options, function (err, res, body) {
-        var errback = captureCommonErrors(err, res);
+    ocapi.retryableCall('GET', API_SANDBOXES, function(err, res) {
         var list = [];
-        if ( errback ) {
-            callback(errback, []);
-            return;
-        } else if ( err ) {
+        if ( err ) {
             callback(new Error(util.format('Retrieving list of sandboxes failed: %s', err)), []);
             return;
         } else if ( res.statusCode >= 400 ) {
             callback(new Error(util.format('Retrieving list of sandboxes failed: %s', res.statusCode)));
             return;
         }
-        callback(undefined, body['data']);
+        callback(undefined, res.body.data);
     });
 }
 
@@ -295,7 +249,7 @@ function createSandbox(realm, ttl, callback) {
         console.info('Using realm id %s from dw.json at %s', dwjson['realm'], process.cwd());
     }
     // build the request options
-    var options = getOptions(API_SANDBOXES, auth.getToken(), 'POST');
+    var options = ocapi.getOptions('POST', API_SANDBOXES);
 
     // prep initial ocapi settings
     var ocapiSettings = SANDBOX_OCAPI_SETTINGS;
@@ -319,18 +273,17 @@ function createSandbox(realm, ttl, callback) {
         options['body']['ttl'] = ttl.toFixed();
     }
 
-    // do the request
-    request.post(options, function (err, res, body) {
+    ocapi.retryableCall('POST', options, function(err, res) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
                 errback = new Error(util.format('Creating sandbox for realm %s failed: %s', realm,
-                    formatError(body.error, res.statusCode)));
+                    formatError(res.body.error, res.statusCode)));
             } else if (err) {
                 errback = new Error(util.format('Creating sandbox for realm %s failed: %s', realm, err));
             }
         }
-        callback(errback, body['data']);
+        callback(errback, res.body['data']);
     });
 }
 
@@ -347,10 +300,9 @@ function getSandbox(id, topic, callback) {
     if ( topic !== null ) {
         extension = '/' + topic
     }
-    var options = getOptions(API_SANDBOXES + '/' + id + extension, auth.getToken(), 'GET');
 
     // do the request
-    request.get(options, function (err, res, body) {
+    ocapi.retryableCall('GET', API_SANDBOXES + '/' + id + extension, function(err, res) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
@@ -360,7 +312,7 @@ function getSandbox(id, topic, callback) {
                 errback = new Error(util.format('Retrieving details for sandbox failed: %s', err));
             }
         }
-        callback(errback, body['data']);
+        callback(errback, res.body['data']);
     });
 }
 
@@ -373,7 +325,7 @@ function getSandbox(id, topic, callback) {
  */
 function updateSandbox(id, ttl, callback) {
     // build the request options
-    var options = getOptions(API_SANDBOXES + '/' + id, auth.getToken(), 'PATCH');
+    var options = ocapi.getOptions('PATCH', API_SANDBOXES + '/' + id);
 
     // the ttl, if passed
     if (ttl) {
@@ -382,18 +334,17 @@ function updateSandbox(id, ttl, callback) {
         };
     }
 
-    // do the request
-    request.patch(options, function (err, res, body) {
+    ocapi.retryableCall('PATCH', options, function(err, res) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
                 errback = new Error(util.format('Updating sandbox failed: %s',
-                    formatError(body.error, res.statusCode)));
+                    formatError(res.body.error, res.statusCode)));
             } else if (err) {
                 errback = new Error(util.format('Updating sandbox failed: %s', err));
             }
         }
-        callback(errback, body['data']);
+        callback(errback, res.body['data']);
     });
 }
 
@@ -404,21 +355,17 @@ function updateSandbox(id, ttl, callback) {
  * @param {Function} callback the callback to execute, the error and the result details are available as arguments to the callback function
  */
 function deleteSandbox(id, callback) {
-    // build the request options
-    var options = getOptions(API_SANDBOXES + '/' + id, auth.getToken(), 'DELETE');
-
-    // do the request
-    request.delete(options, function (err, res, body) {
+    ocapi.retryableCall('DELETE', API_SANDBOXES + '/' + id, function(err, res) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
                 errback = new Error(util.format('Removing sandbox failed: %s',
-                    formatError(body.error, res.statusCode)));
+                    formatError(res.body.error, res.statusCode)));
             } else if (err) {
                 errback = new Error(util.format('Removing sandbox failed: %s', err));
             }
         }
-        callback(errback, body);
+        callback(errback, res.body);
     });
 }
 
@@ -430,25 +377,23 @@ function deleteSandbox(id, callback) {
  * @param {Function} callback the callback to execute, the error and the result details are available as arguments to the callback function
  */
 function triggerOperation(id, operation, callback) {
-    // build the request options
-    var options = getOptions(API_SANDBOXES + '/' + id + '/operations', auth.getToken(), 'POST');
+    var options = ocapi.getOptions('POST', API_SANDBOXES + '/' + id + '/operations');
 
     // the payload
     options['body'] = {
         operation : operation
     };
 
-    // do the request
-    request.post(options, function (err, res, body) {
+    ocapi.retryableCall('POST', options, function(err, res) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
-                errback = new Error(util.format('Operation failed: %s', formatError(body.error, res.statusCode)));
+                errback = new Error(util.format('Operation failed: %s', formatError(res.body.error, res.statusCode)));
             } else if (err) {
                 errback = new Error(util.format('Operation failed: %s', err));
             }
         }
-        callback(errback, body);
+        callback(errback, res.body);
     });
 }
 


### PR DESCRIPTION
This reworks auth.renew to use an available refresh_token to replace an expired access token.

To simplify working with the retry logic, this PR introduces an ocapi.retryableCall method that automatically retries the specified call after refreshing the access token. All sandbox related methods are updated to use this method.