### PR TITLE
Introduce `formatError` to gracefully handle unknown error format

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -304,8 +304,7 @@ function createSandbox(realm, ttl, callback) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
-                errback = new Error(util.format('Creating sandbox for realm %s failed: %s', realm,
-                    body.error.message));
+                errback = new Error(util.format('Creating sandbox for realm %s failed: %s', realm, formatError(body.error, res.statusCode)));
             } else if (err) {
                 errback = new Error(util.format('Creating sandbox for realm %s failed: %s', realm, err));
             }
@@ -328,7 +327,7 @@ function getSandbox(id, callback) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
-                errback = new Error(util.format('Retrieving details for sandbox failed: %s', body.message));
+                errback = new Error(util.format('Retrieving details for sandbox failed: %s', formatError(body.error, res.statusCode)));
             } else if (err) {
                 errback = new Error(util.format('Retrieving details for sandbox failed: %s', err));
             }
@@ -360,7 +359,7 @@ function updateSandbox(id, ttl, callback) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
-                errback = new Error(util.format('Updating sandbox failed: %s', body.message));
+                errback = new Error(util.format('Updating sandbox failed: %s', formatError(body.error, res.statusCode)));
             } else if (err) {
                 errback = new Error(util.format('Updating sandbox failed: %s', err));
             }
@@ -384,7 +383,7 @@ function removeSandbox(id, callback) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
-                errback = new Error(util.format('Removing sandbox failed: %s', body.message));
+                errback = new Error(util.format('Removing sandbox failed: %s', formatError(body.error, res.statusCode)));
             } else if (err) {
                 errback = new Error(util.format('Removing sandbox failed: %s', err));
             }
@@ -414,13 +413,17 @@ function triggerOperation(id, operation, callback) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
             if (res.statusCode >= 400) {
-                errback = new Error(util.format('Operation failed: %s', body.error.message));
+                errback = new Error(util.format('Operation failed: %s', formatError(body.error, res.statusCode)));
             } else if (err) {
                 errback = new Error(util.format('Operation failed: %s', err));
             }
         }
         callback(errback, body);
     });
+}
+
+function formatError(error, statusCode) {
+    return error ? error.message : "unknown error (code " + statusCode + ")";
 }
 
 module.exports.cli = {


### PR DESCRIPTION
Fixes #24 