### PR TITLE
Treat client_credentials grants as renewable (fixes #33)

### DIFF
--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -144,6 +144,24 @@ else
 	exit 1
 fi
 
+echo "Testing command ´sfcc-ci client:auth´ with --renew option and resource owner grant:"
+node ./cli.js client:auth $TEST_CLIENT_ID $TEST_CLIENT_SECRET $TEST_USER $TEST_USER_PW --renew
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
+echo "Testing command ´sfcc-ci client:renew´ (expected to succeed):"
+node ./cli.js client:auth:renew
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
 ###############################################################################
 ###### Testing ´sfcc-ci auth:logout´
 ###############################################################################

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -203,8 +203,9 @@ function auth(client, clientSecret, user, userPassword, autoRenew, accountManage
             setAccessToken(res.body.access_token);
 
             // the auto renew requires to store the base64 encoded client and secret
-            if (autoRenew && res.body['refresh_token']) {
+            if (autoRenew) {
                 var credentials = Buffer.from(client + ':' + clientSecret).toString('base64');
+                // token might null, that's ok
                 setAutoRenewToken(credentials, res.body['refresh_token']);
             } else {
                 setAutoRenewToken(null, null);
@@ -234,6 +235,9 @@ function auth(client, clientSecret, user, userPassword, autoRenew, accountManage
  * For this to work, `client:auth` or `client:login` must have been called with
  * the `--renew` flag. We don't store the necessary information otherwise.
  *
+ * If the original authentication was with client id and secret only (client_credentials grant), this will result in
+ * another `client_credentials` grant (similar to calling {@link #auth} directly).
+ *
  * A successful token refresh will update the stored access token and may
  * update the stored refresh token.
  *
@@ -252,7 +256,9 @@ function renew(callback) {
     var basicString = Buffer.from(basicEncoded, 'base64').toString().split(':'),
         client = basicString[0],
         secret = basicString[1],
-        grant = { grant_type: 'refresh_token', refresh_token: getRefreshToken() };
+        grant = getRefreshToken() != null
+            ? { grant_type: 'refresh_token', refresh_token: getRefreshToken() }
+            : { grant_type: 'client_credentials', response_type: 'token' };
 
     // attempt to obtain a new token using the previously stored encoded basic
     obtainToken(null, client, secret, grant, function (err, res) {
@@ -274,7 +280,7 @@ function renew(callback) {
 }
 
 function isRenewable() {
-    return getAutoRenewBase64() && getRefreshToken();
+    return getAutoRenewBase64();
 }
 
 function getClient() {
@@ -310,7 +316,11 @@ function getRefreshToken() {
 }
 
 function setRefreshToken(token) {
-    config.set('SFCC_REFRESH_TOKEN', token);
+    if (token == null) {
+        config.delete('SFCC_REFRESH_TOKEN');
+    } else {
+        config.set('SFCC_REFRESH_TOKEN', token);
+    }
 }
 
 function setAutoRenewToken(credentials, refresh_token) {

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -165,13 +165,15 @@ describe('Tests for lib/auth.js', function() {
             config.set('SFCC_REFRESH_TOKEN', refreshToken);
         });
 
-        it('rejects call when no renew token present', function() {
+        it('no refresh token results in client_credentials auth', function() {
             config.set('SFCC_REFRESH_TOKEN', null);
 
             auth.renew(callback);
 
-            sinon.assert.notCalled(requestStub.post);
-            sinon.assert.notCalled(callback);
+            sinon.assert.calledOnce(requestStub.post);
+
+            const postArgs = requestStub.post.getCall(0).args[0];
+            expect(postArgs.form.grant_type).to.equal('client_credentials');
         });
 
         it('makes call to AM with stored credentials', function() {


### PR DESCRIPTION
This is possible because we encode both client id and secret when `--renew` is requested. Just issue a new grant request when using client_credentials (doesn't use a refresh_token).