### PR TITLE
Avoid calling unnecessary second callback

### DIFF
--- a/lib/webdav.js
+++ b/lib/webdav.js
@@ -298,6 +298,7 @@ function deployCodeAPI(instance, archive, token, options, callback) {
                     } else {
                         if (res && res.statusCode === 204) {
                             callback(undefined);
+                            return;
                         } else {
                             callback(new Error(`Delete ZIP file ${file} after deployment failed (deleteFile step): `
                                 + `${res.statusCode} (${res.statusMessage})`));


### PR DESCRIPTION
Return after first callback, since the second one is not needed