### PR TITLE
Allow to have a callback after sandbox creation has been completed

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -401,6 +401,94 @@ function formatError(error, statusCode) {
     return error ? error.message : "unknown error (code " + statusCode + ")";
 }
 
+/**
+ *
+ * @param {Object} newSandbox - Nodejs common response object which includes new
+ * @param {Object} callback - JS callback function
+ */
+function sandboxCreateAsync(newSandboxResponse, callback) {
+    var finished = false;
+    var fault = null;
+    var errorThreshold = SANDBOX_STATUS_POLL_ERROR_THRESHOLD;
+    var duration = 0;
+    var asJson = newSandboxResponse.asJson;
+    var timeout = setInterval(function() {
+        // poll the status
+        getSandbox(newSandboxResponse.id, null, function(err, sandbox) {
+            // check if operation timeout has been exceeded
+            if ( Date.now() - newSandboxResponse.timings.startTime > API_SANDBOXES_OPERATION_TIMEOUT ) {
+                // report an exceeded operation timeout
+                fault = {
+                    message : 'Sandbox creation timeout has been exceeded.'
+                };
+            } else if (err && errorThreshold > 0) {
+                // in case status retrieval failed
+                // decrease the error threshold
+                errorThreshold--;
+                // don't set an error and allow the polling to continue
+                console.debug('Polling sandbox status failed. Polling error threshold not reached.');
+            } else if (err && errorThreshold === 0) {
+                // report a reached error threshold during polling
+                fault = {
+                    message : 'Polling sandbox status failed. Error threshold reached. Stop polling, ' +
+                        'the creation may still continue. Detailed error was ' + err.message
+                };
+            } else if (!err) {
+                // status retrieved
+                // update the status
+                result.sandbox = sandbox;
+                if (sandbox && sandbox.state === SANDBOX_STATUS_UP_AND_RUNNING ) {
+                    finished = true;
+                } else if (sandbox && sandbox.state === SANDBOX_STATUS_FAILED ) {
+                    // report a failed sandbox
+                    fault = {
+                        message : 'Sandbox creation resulted in sandbox of status `failed`'
+                    };
+                }
+            }
+
+            if (!finished && !fault) {
+                // continue polling
+                return;
+            }
+
+            // update duration
+            duration = Date.now() - newSandbox.timings.startTime;
+            // skip polling
+            clearInterval(timeout);
+
+            if (fault) {
+                // the sandbox creation was triggered, but the polling failed or sandbox state is failed
+                // treat this as error
+                result.error = fault.message;
+                console.error(result.error);
+            } else {
+                // TODO append message (e.g. from default set)
+                result.message = util.format('Creation of new sandbox %s for realm %s finished (%s ms). ' +
+                    'Sandbox id is %s, status of sandbox is %s. You may use `sfcc-ci sandbox:list` to ' +
+                    'check the status of the creation.', result.sandbox.instance, result.sandbox.realm,
+                duration, result.sandbox.id, result.sandbox.state);
+            }
+
+            // format output as JSON if needed
+            if (asJson) {
+                console.json(result);
+                return;
+            }
+
+            // plain output
+            console.info(result.message);
+            if (result.warning) {
+                console.warn(result.warning);
+            }
+            if (callback !== undefined) {
+                callback(result);
+            }
+        });
+    }, SANDBOX_STATUS_POLL_TIMEOUT);
+}
+
+
 module.exports.cli = {
     realm : {
         /**
@@ -548,7 +636,6 @@ module.exports.cli = {
     create : function(realm, alias, ttl, asJson, sync, setAsDefault) {
         // memorize the start time and duration
         var startTime = Date.now();
-        var duration = 0;
 
         createSandbox(realm, ttl, function(err, newSandbox) {
             if (err) {
@@ -564,7 +651,7 @@ module.exports.cli = {
             var result = {
                 message : util.format('Creation of new sandbox %s for realm %s triggered and ongoing. ' +
                     'Sandbox id is %s, status of sandbox is %s. You may use `sfcc-ci sandbox:list` to ' +
-                    'check the status of the sandbox.', newSandbox.instance, newSandbox.realm, newSandbox.id,
+                    'check the status of the creation.', newSandbox.instance, newSandbox.realm, newSandbox.id,
                 newSandbox.state),
                 sandbox : newSandbox };
 
@@ -619,90 +706,14 @@ module.exports.cli = {
             }
 
             // in sync mode, read the details of the sandbox we have just triggered creation for
-
-            // no failure
-            var finished = false;
-            var fault = null;
-
-            // error threshold
-            var errorThreshold = SANDBOX_STATUS_POLL_ERROR_THRESHOLD;
-
-            // monitor creation and status updates until either status of new sandbox is started or operation
-            // timeout has been reached
-            var timeout = setInterval(function() {
-                // poll the status
-                getSandbox(newSandbox.id, null, function(err, sandbox) {
-                    // check if operation timeout has been exceeded
-                    if ( Date.now() - startTime > API_SANDBOXES_OPERATION_TIMEOUT ) {
-                        // report an exceeded operation timeout
-                        fault = {
-                            message : 'Sandbox creation timeout has been exceeded.'
-                        };
-                    } else if (err && errorThreshold > 0) {
-                        // in case status retrieval failed
-                        // decrease the error threshold
-                        errorThreshold--;
-                        // don't set an error and allow the polling to continue
-                        console.debug('Polling sandbox status failed. Polling error threshold not reached.');
-                    } else if (err && errorThreshold === 0) {
-                        // report a reached error threshold during polling
-                        fault = {
-                            message : 'Polling sandbox status failed. Error threshold reached. Stop polling, ' +
-                                'the creation may still continue. Detailed error was ' + err.message
-                        };
-                    } else if (!err) {
-                        // status retrieved
-                        // update the status
-                        //newSandbox = sandbox;
-                        result['sandbox'] = sandbox;
-                        if (sandbox && sandbox.state === SANDBOX_STATUS_UP_AND_RUNNING ) {
-                            finished = true;
-                        } else if (sandbox && sandbox.state === SANDBOX_STATUS_FAILED ) {
-                            // report a failed sandbox
-                            fault = {
-                                message : 'Sandbox creation resulted in sandbox of status `failed`'
-                            };
-                        }
-                    }
-
-                    if (!finished && !fault) {
-                        // continue polling
-                        return;
-                    }
-
-                    // update duration
-                    duration = Date.now() - startTime;
-                    // skip polling
-                    clearInterval(timeout);
-
-                    if (fault) {
-                        // the sandbox creation was triggered, but the polling failed or sandbox state is failed
-                        // treat this as error
-                        result['error'] = fault.message;
-                    } else {
-                        // TODO append message (e.g. from default set)
-                        result['message'] = util.format('Creation of new sandbox %s for realm %s finished (%s ms). ' +
-                            'Sandbox id is %s, status of sandbox is %s. You may use `sfcc-ci sandbox:list` to ' +
-                            'check the status of the sandbox.', result['sandbox'].instance, result['sandbox'].realm,
-                        duration, result['sandbox'].id, result['sandbox'].state);
-                    }
-
-                    // format output as JSON if needed
-                    if ( asJson ) {
-                        console.json(result);
-                        return;
-                    }
-
-                    // plain output
-                    console.info(result['message']);
-                    if (result['warning']) {
-                        console.warn(result['warning']);
-                    }
-                    if (result['error']) {
-                        console.error(result['error']);
-                    }
-                });
-            }, SANDBOX_STATUS_POLL_TIMEOUT);
+            // sandbox creation is async but since we choose async mode we will not wait for the completion
+            sandbox.timings = {
+                startTime: startTime
+            }
+            sandbox.output = {
+                asJson: asJson
+            }
+            sandboxCreateAsync(sandbox);
         });
     },
 


### PR DESCRIPTION
This PR adressses https://github.com/SalesforceCommerceCloud/sfcc-ci/issues/52

To make the sandbox creation logic work within a JS-api at a later time, a callback needs to be passed to the sandbox creation.