### PR TITLE
#66 add support for retrieving detailed sandbox storage capacity

### DIFF
--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -474,6 +474,15 @@ else
 	exit 1
 fi
 
+echo "Testing command ´sfcc-ci sandbox:get --sandbox <sandbox> --show-storage´:"
+node ./cli.js sandbox:get --sandbox $TEST_NEW_SANDBOX_ID --show-storage
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
 ###############################################################################
 ###### Testing ´sfcc-ci sandbox:update´
 ###############################################################################

--- a/cli.js
+++ b/cli.js
@@ -305,6 +305,7 @@ program
     .option('--show-operations','Display operations performed')
     .option('--show-usage','Display detailed usage information')
     .option('--show-settings','Display settings applied')
+    .option('--show-storage','Display detailed storage information')
     .action(function(options) {
         var sandbox_id = ( options.sandbox ? options.sandbox : null );
         if (!sandbox_id) {
@@ -322,10 +323,17 @@ program
         var asJson = ( options.json ? options.json : false );
         var hostOnly = ( options.host ? options.host : false );
         var openBrowser = ( options.open ? options.open : false );
-        var showOperations = ( options.showOperations ? options.showOperations : false );
-        var showUsage = ( options.showUsage ? options.showUsage : false );
-        var showSettings = ( options.showSettings ? options.showSettings : false );
-        require('./lib/sandbox').cli.get(spec, asJson, hostOnly, openBrowser, showOperations, showUsage, showSettings);
+        var topic = null;
+        if ( options.showOperations ) {
+            topic = 'operations';
+        } else if ( options.showUsage ) {
+            topic = 'usage';
+        } else if ( options.showSettings ) {
+            topic = 'settings';
+        } else if ( options.showStorage ) {
+            topic = 'storage';
+        }
+        require('./lib/sandbox').cli.get(spec, asJson, hostOnly, openBrowser, topic);
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -337,7 +345,8 @@ program
         console.log();
         console.log('  Use --show-usage to display detailed usage information, --show-operations to get a list of');
         console.log('  previous operations executed on the sandbox, --show-settings to return the settings initially');
-        console.log('  applied to the sandbox during creation.');
+        console.log('  applied to the sandbox during creation. Use --show-storage to retrieve detailed storage');
+        console.log('  capacity.');
         console.log('');
         console.log('  Examples:');
         console.log();
@@ -348,6 +357,7 @@ program
         console.log('    $ sfcc-ci sandbox:get -s my-sandbox-id --show-usage');
         console.log('    $ sfcc-ci sandbox:get -s my-sandbox-id --show-operations');
         console.log('    $ sfcc-ci sandbox:get -s my-sandbox-id --show-settings');
+        console.log('    $ sfcc-ci sandbox:get -s my-sandbox-id --show-storage');
         console.log();
     });
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -716,11 +716,9 @@ module.exports.cli = {
      * @param {Boolean} asJson optional flag to force output in json, false by default
      * @param {Boolean} hostOnly optional flag to return the well-defined host name of the sandbox, false by default
      * @param {Boolean} openBrowser optional flag to open a browser to the Business Manager, false by default
-     * @param {Boolean} showOperations optional flag to return sandbox operations, false by default
-     * @param {Boolean} showUsage optional flag to return sandbox usage, false by default
-     * @param {Boolean} showSettings optional flag to return settings, false by default
+     * @param {String} topic topic to retrieve details for
      */
-    get : function(spec, asJson, hostOnly, openBrowser, showOperations, showUsage, showSettings) {
+    get : function(spec, asJson, hostOnly, openBrowser, topic) {
         // sandbox to determine
         var foundSandbox = null;
 
@@ -774,11 +772,8 @@ module.exports.cli = {
                 console.info('Opening browser to Business Manager...');
                 open(bmUrl);
                 return;
-            } else if (showOperations || showUsage || showSettings) {
+            } else if (topic) {
                 // get topic details
-                var topic = 'operations';
-                if ( showUsage ) topic = 'usage';
-                if ( showSettings ) topic = 'settings';
                 getSandbox(foundSandbox['id'], topic, function(error, sandbox) {
                     if (asJson) {
                         console.json(sandbox);


### PR DESCRIPTION
Allows to pull sandbox storage capacity via optional flag `--show-storage` for command `sfcc-ci sandbox:get`, for example

```
sfcc-ci sandbox:get --sandbox zzzz --show-storage
```