### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: sfcc-ci
+
+on:
+  push:
+  pull_request:
+
+env:
+  GITHUB: ${{ toJson(github) }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  workflow:
+    name: Workflow
+    runs-on: ubuntu-latest
+    steps:
+    - id: check-out
+      name: Check out
+      uses: actions/checkout@v2
+
+    - id: help
+      name: Help
+      uses: ./
+      with:
+        command: 'sfcc-ci --version'
+    
+    - id: help-result
+      name: Help result
+      run: |
+        echo "${{ steps.help.outputs.result }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   workflow:
-    name: Workflow
+    name: workflow
     runs-on: ubuntu-latest
     steps:
     - id: check-out
@@ -35,6 +35,11 @@ jobs:
     - run: |
         npm install
 
+    - id: lint
+      name: Lint
+      run: |
+        npm run lint
+
     - id: version
       name: Version
       uses: ./
@@ -44,4 +49,4 @@ jobs:
     - id: version-result
       name: Version result
       run: |
-        echo "${{ steps.help.outputs.result }}"
+        echo "${{ steps.version.outputs.result }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,28 @@ jobs:
       name: Check out
       uses: actions/checkout@v2
 
-    - id: help
-      name: Help
+    - id: cache
+      name: Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          **/node_modules
+        key: node-modules-${{ hashFiles('package.json') }}
+
+    - id: install-dependencies
+      name: Install dependencies
+      uses: actions/setup-node@v1
+      if: steps.cache.outputs.cache-hit != 'true'
+    - run: |
+        npm install
+
+    - id: version
+      name: Version
       uses: ./
       with:
         command: 'sfcc-ci --version'
-    
-    - id: help-result
-      name: Help result
+
+    - id: version-result
+      name: Version result
       run: |
         echo "${{ steps.help.outputs.result }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 coverage
 dist
 node_modules
-.*
 *.iml

--- a/action.js
+++ b/action.js
@@ -1,0 +1,21 @@
+const core = require('@actions/core');
+const exec = require('@actions/exec');
+
+(async () => {
+    try {
+        const command = core.getInput('command', { required: true });
+
+        let result = '';
+        await exec.exec('node', command.replace('sfcc-ci', 'cli.js').split(' ').filter(c => c !== ''), {
+            listeners: {
+                stdout: (data) => {
+                    result += data.toString();
+                }
+            }
+        });
+
+        core.setOutput('result', result);
+    } catch (error) {
+        core.setFailed(error.message);
+    }
+})();

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,21 @@
+name: 'sfcc-ci'
+
+description: 'Command line tool to allow Continuous Integration practices with Salesforce Commerce Cloud instances'
+
+author: 'Salesforce'
+
+branding:
+  icon: 'cloud'
+  color: 'blue'
+
+inputs:
+  command:
+    description: 'Command'
+    required: false
+outputs:
+  result:
+    description: 'Result'
+
+runs:
+  using: 'node12'
+  main: './action.js'

--- a/package.json
+++ b/package.json
@@ -24,17 +24,8 @@
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/SalesforceCommerceCloud/sfcc-ci#readme",
   "dependencies": {
-    "chalk": "^2.4.1",
-    "commander": "^2.18.0",
-    "conf": "^4.0.2",
-    "dotenv": "^8.2.0",
-    "inquirer": "^6.2.0",
-    "jsonwebtoken": "^8.3.0",
-    "open": "^6.4.0",
-    "request": "^2.88.0",
-    "request-debug": "^0.2.0",
-    "table": "^5.0.2",
-    "snyk": "^1.330.3"
+    "@actions/core": "1.2.6",
+    "@actions/exec": "1.0.4",
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,17 @@
   "dependencies": {
     "@actions/core": "1.2.6",
     "@actions/exec": "1.0.4",
+    "chalk": "^2.4.1",
+    "commander": "^2.18.0",
+    "conf": "^4.0.2",
+    "dotenv": "^8.2.0",
+    "inquirer": "^6.2.0",
+    "jsonwebtoken": "^8.3.0",
+    "open": "^6.4.0",
+    "request": "^2.88.0",
+    "request-debug": "^0.2.0",
+    "table": "^5.0.2",
+    "snyk": "^1.330.3"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Hi,

Following up on #159 with this draft. Let's discuss it here, then when we're all sure you can merge it back.

By using this, now I can pass environment variables via `env:` option and run all sfcc-ci commands smoothly. If there's a result (either in JSON or plain text) it goes back into `result` output, so the rest of the actions can read it via `steps.<step_id>.outputs.result`. 

My only worry is, this might require a minor bump in the version, rather than a patch. But as far as I can see, it's somewhat working and needs more testing. 

I hope this makes sense.

Best,
G.