### PR TITLE
Document installing using `npm` directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,15 @@ If do not want to use the JavaScript API, but just the CLI you don't need Node.j
 
 ## Installation Instructions ##
 
-You can install the CLI using a pre-built binary or from source using Node.js.
+You can install the CLI from `npm`, using a pre-built binary or from source using Node.js.
+
+### Install from `npm` ###
+
+If you already have [Node.js](https://nodejs.org/en/download/) installed, you can install globally using `npm`:
+
+```sh
+npm install -g sfcc-ci
+```
 
 ### Install Prebuilt Binary ###
 

--- a/README.md
+++ b/README.md
@@ -214,10 +214,13 @@ You can install the CLI from `npm`, using a pre-built binary or from source usin
 
 ### Install from `npm` ###
 
-If you already have [Node.js](https://nodejs.org/en/download/) installed, you can install globally using `npm`:
+If you already have [Node.js](https://nodejs.org/en/download/) installed, you can install globally using `npm` or run using [`npx`](https://docs.npmjs.com/cli/v7/commands/npx):
 
 ```sh
 npm install -g sfcc-ci
+
+# Or alternatively, using npx:
+npx sfcc-ci
 ```
 
 ### Install Prebuilt Binary ###


### PR DESCRIPTION
For folks that already have Node.js installed, which increasingly will become most SFCC developers as its a requirement of PWA Kit, I believe the most straight forward way to start using `sfcc-ci` will be install it directly from `npm` as it appears the tool is already available there: https://www.npmjs.com/package/sfcc-ci

This change adds that instruction to the top of the list of possible ways to install the tool.