### PR TITLE
Add support for creating sandbox alias to be unique

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -724,9 +724,11 @@ program
         console.log('');
         console.log('  Use the --unique flag allows you to configure the alias to be unique across all aliases');
         console.log('  registered. This requires that you have to proof ownership of the host on a DNS level.');
-        console.log('  By default the alias is not unique.');
+        console.log('  The domain verification record value is generated and returned. By default the alias is not');
+        console.log('  unique.');
         console.log('');
-        console.log('  Use --json to only print the created alias incl. the registration link.');
+        console.log('  Use --json to only print the created alias incl. either the registration link or the');
+        console.log('  the domain verification record.');
         console.log('');
         console.log('  Examples:');
         console.log();

--- a/cli.js
+++ b/cli.js
@@ -687,6 +687,7 @@ program
     .option('-s, --sandbox <id>','sandbox to create alias for')
     .option('-h, --host <host>','hostname alias to register')
     .option('-j, --json', 'Optional, formats the output in json')
+    .option('-u, --unique', 'Optional, define alias as unique, false by default')
     .description('Registers a hostname alias for a sandbox.')
     .action(function(options) {
         var sandbox = options.sandbox;
@@ -710,7 +711,8 @@ program
             return;
         }
         var asJson = ( options.json ? options.json : false );
-        require('./lib/sandbox').cli.alias.create(spec, aliasName, asJson);
+        var unique = ( options.unique ? options.unique : false );
+        require('./lib/sandbox').cli.alias.create(spec, aliasName, unique, asJson);
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -719,6 +721,10 @@ program
         console.log('  as soon as you have inserted the domain and a given target IP in your etc/hosts file. ');
         console.log('  Note that you also have to include the hostname in your site alias configuration in Business');
         console.log('  Manager to make the following redirect to your storefront working.');
+        console.log('');
+        console.log('  Use the --unique flag allows you to configure the alias to be unique across all aliases');
+        console.log('  registered. This requires that you have to proof ownership of the host on a DNS level.');
+        console.log('  By default the alias is not unique.');
         console.log('');
         console.log('  Use --json to only print the created alias incl. the registration link.');
         console.log('');

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1512,7 +1512,16 @@ module.exports.cli = {
                         return;
                     }
                     if (asJson) {
+                        // only log sandbox alias details to console
                         console.json(result)
+                    } else if (result.domainVerificationRecord) {
+                        // it's a unique alias, display domain verification record required
+                        console.prettyPrint(result);
+                        console.log('Please point the domain (' + result.name + ') to one of the inbound IP ' +
+                        'addresses and set the alias in your instance\'s site alias configuration (in Business ' +
+                        'Manager at: Merchant Tools > SEO > Aliases). In addition set the domain verification ' +
+                        '(' + result.domainVerificationRecord + ') as TXT record at domain or root level. The TXT ' +
+                        'record is checked every 15 mins after which your created alias is usable.');
                     } else {
                         // open registration link automatically if in interactive mode
                         // assuming this is the case when --json flag is not used
@@ -1580,9 +1589,10 @@ module.exports.cli = {
                         return;
                     }
                     // table fields
-                    var data = [['id','name','sandbox','register']];
+                    var data = [['id','name','status','registration','domainVerificationRecord']];
                     for (var i of list) {
-                        data.push([i.id, i.name, i.sandboxId, i.registration]);
+                        data.push([i.id, i.name, i.status, i.registration,
+                            i.domainVerificationRecord]);
                     }
                     console.table(data);
                 });

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -637,12 +637,13 @@ function doCookieRegistration(link, host) {
  *
  * @param sbxID ID of the sandbox to create alias for
  * @param alias name of the alias to create
+ * @param unique true, if the alias is unique across aliases, false by default
  * @param {Function} callback the callback to execute, the error and the created alias are available as arguments to the callback function
  */
-function registerForSandbox(sbxID, alias, callback) {
+function registerForSandbox(sbxID, alias, unique, callback) {
     // the payload
     var options = ocapi.getOptions('POST', API_SANDBOXES + '/' + sbxID + '/aliases');
-    options['body'] = {name: alias};
+    options['body'] = {name: alias, unique: !!unique};
 
     ocapi.retryableCall('POST', options, function (err, res) {
         if (err) {
@@ -1496,11 +1497,12 @@ module.exports.cli = {
          *
          * @param {String} spec the sandbox id or tenant
          * @param {String} alias the alias name to register for the sandbox
+         * @param {Boolean} unique optional flag to configure the alias to be unique, false by default
          * @param {Boolean} asJson optional flag to force output in json, false by default
          */
-        create : function (spec, alias, asJson) {
+        create : function (spec, alias, unique, asJson) {
             runForSandbox(spec, asJson, function (sandbox) {
-                registerForSandbox(sandbox, alias, function (err, result) {
+                registerForSandbox(sandbox, alias, unique, function (err, result) {
                     if (err) {
                         if (asJson) {
                             console.json({error: err.message});

--- a/test/unit/sandbox.js
+++ b/test/unit/sandbox.js
@@ -128,21 +128,21 @@ describe('Alias Tests for lib/sandbox.js', function() {
 
     describe('Create Alias', function() {
         it('Create alias', () => {
-            sandbox.cli.alias.create({id: "s1"},"alias", true);
+            sandbox.cli.alias.create({id: "s1"},"alias", false, true);
             sinon.assert.calledWith(consJson, existingAlias.data);
-            sandbox.cli.alias.create({id: "s1"},"alias", false);
+            sandbox.cli.alias.create({id: "s1"},"alias", false, false);
             sinon.assert.calledWith(consPretty, existingAlias.data);
         });
         it('Create SBX alias, invalid sandbox', () => {
-            sandbox.cli.alias.create({id: "invalidSandboxId"},"alias", true);
+            sandbox.cli.alias.create({id: "invalidSandboxId"},"alias", false, true);
             sinon.assert.calledWith(consJson, {error: "Creating sandbox alias failed: Invalid sandbox ID."});
-            sandbox.cli.alias.create({id: "invalidSandboxId"},"alias", false);
+            sandbox.cli.alias.create({id: "invalidSandboxId"},"alias", false, false);
             sinon.assert.calledWith(consError, "Creating sandbox alias failed: Invalid sandbox ID.");
         });
         it('Create SBX alias, sandbox not found', () => {
-            sandbox.cli.alias.create({id: "unknownSandboxId"},"alias", true);
+            sandbox.cli.alias.create({id: "unknownSandboxId"},"alias", false, true);
             sinon.assert.calledWith(consJson, {error: "Creating sandbox alias failed: Sandbox not found."});
-            sandbox.cli.alias.create({id: "unknownSandboxId"},"alias", false);
+            sandbox.cli.alias.create({id: "unknownSandboxId"},"alias", false, false);
             sinon.assert.calledWith(consError, "Creating sandbox alias failed: Sandbox not found.");
         });
     })

--- a/test/unit/sandbox.js
+++ b/test/unit/sandbox.js
@@ -38,7 +38,16 @@ describe('Alias Tests for lib/sandbox.js', function() {
             id: "a1",
             name: "www.example.com",
             sandboxId: "s1",
-            registration: "link"
+            status: "pending",
+            registration: "link",
+            domainVerificationRecord: null
+        },{
+            id: "a2",
+            name: "www2.example.com",
+            sandboxId: "s1",
+            status: "success",
+            registration: null,
+            domainVerificationRecord: "verify=yes"
         }]
     };
     var sandbox = proxyquire('../../lib/sandbox', {
@@ -152,8 +161,10 @@ describe('Alias Tests for lib/sandbox.js', function() {
             sandbox.cli.alias.list({id: "s1"}, true);
             sinon.assert.calledWith(consJson, aliasList.data);
             sandbox.cli.alias.list({id: "s1"}, false);
-            sinon.assert.calledWith(consTable, [['id','name','sandbox','register'],
-                ["a1","www.example.com","s1","link"]]);
+            sinon.assert.calledWith(consTable, [
+                ['id','name','status','registration','domainVerificationRecord'],
+                ["a1","www.example.com","pending","link",null],
+                ["a2","www2.example.com","success",null,"verify=yes"]]);
         });
         it('List aliases, invalid sandbox ID', () => {
             sandbox.cli.alias.list({id: "invalidSandboxId"}, true);


### PR DESCRIPTION
Add support for creating sandbox alias to be unique. Added parameter `--unique` to command `sfcc-ci  sandbox:alias:add`