### PR TITLE
Add sync flag to sandbox:start and sandbox:stop

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -477,12 +477,11 @@ program
 program
     .command('sandbox:start')
     .option('-s, --sandbox <id>','sandbox to start')
-    .option('-w, --sync', 'Operates in synchronous mode and waits until the operation has been finished.')
+    .option('-w, --sync','Operates in synchronous mode and waits until the operation has finished.')
     .description('Start a sandbox')
     .action(function(options) {
         var sandbox_id = ( options.sandbox ? options.sandbox : null );
         var sync = ( options.sync ? options.sync : false );
-
         if (!sandbox_id) {
             this.missingArgument('sandbox');
             return;
@@ -505,7 +504,7 @@ program
         console.log();
         console.log('  You can also pass the realm and the instance (e.g. zzzz-s01) as <id>.');
         console.log();
-        console.log('  Use the --sync flag to wait for the sandbox to return a status of `started`.');
+        console.log('  Use the --sync flag to wait for the sandbox to have `started` status.');
         console.log();
         console.log('  Examples:');
         console.log();

--- a/cli.js
+++ b/cli.js
@@ -516,9 +516,11 @@ program
 program
     .command('sandbox:stop')
     .option('-s, --sandbox <id>','sandbox to stop')
+    .option('-w, --sync','Operates in synchronous mode and waits until the operation has finished.')
     .description('Stop a sandbox')
     .action(function(options) {
         var sandbox_id = ( options.sandbox ? options.sandbox : null );
+        var sync = ( options.sync ? options.sync : false );
         if (!sandbox_id) {
             this.missingArgument('sandbox');
             return;
@@ -531,7 +533,7 @@ program
             spec['realm'] = split[0];
             spec['instance'] = split[1];
         }
-        require('./lib/sandbox').cli.stop(spec, false);
+        require('./lib/sandbox').cli.stop(spec, false, sync);
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -540,10 +542,13 @@ program
         console.log('  identify the id of your sandboxes.');
         console.log();
         console.log('  You can also pass the realm and the instance (e.g. zzzz-s01) as <id>.');
-        console.log('');
+        console.log();
+        console.log('  Use the --sync flag to wait for the sandbox to have `started` status.');
+        console.log();
         console.log('  Examples:');
         console.log();
         console.log('    $ sfcc-ci sandbox:stop --sandbox my-sandbox-id');
+        console.log('    $ sfcc-ci sandbox:stop --sandbox my-sandbox-id --sync');
         console.log();
     });
 

--- a/cli.js
+++ b/cli.js
@@ -477,9 +477,12 @@ program
 program
     .command('sandbox:start')
     .option('-s, --sandbox <id>','sandbox to start')
+    .option('-w, --sync', 'Operates in synchronous mode and waits until the operation has been finished.')
     .description('Start a sandbox')
     .action(function(options) {
         var sandbox_id = ( options.sandbox ? options.sandbox : null );
+        var sync = ( options.sync ? options.sync : false );
+
         if (!sandbox_id) {
             this.missingArgument('sandbox');
             return;
@@ -492,7 +495,7 @@ program
             spec['realm'] = split[0];
             spec['instance'] = split[1];
         }
-        require('./lib/sandbox').cli.start(spec, false);
+        require('./lib/sandbox').cli.start(spec, false, sync);
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -501,10 +504,13 @@ program
         console.log('  identify the id of your sandboxes.');
         console.log();
         console.log('  You can also pass the realm and the instance (e.g. zzzz-s01) as <id>.');
-        console.log('');
+        console.log();
+        console.log('  Use the --sync flag to wait for the sandbox to return a status of `started`.');
+        console.log();
         console.log('  Examples:');
         console.log();
         console.log('    $ sfcc-ci sandbox:start --sandbox my-sandbox-id');
+        console.log('    $ sfcc-ci sandbox:start --sandbox my-sandbox-id --sync');
         console.log();
     });
 

--- a/cli.js
+++ b/cli.js
@@ -543,7 +543,7 @@ program
         console.log();
         console.log('  You can also pass the realm and the instance (e.g. zzzz-s01) as <id>.');
         console.log();
-        console.log('  Use the --sync flag to wait for the sandbox to have `started` status.');
+        console.log('  Use the --sync flag to wait for the sandbox to have `stopped` status.');
         console.log();
         console.log('  Examples:');
         console.log();

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1445,7 +1445,7 @@ module.exports.cli = {
                         console.info('Stopping %s triggered. You may use `sfcc-ci sandbox:list` to check the ' +
                         'status of the operation.', foundSandbox.id);
                     } else {
-                        console.info('Stopping %s was triggered. Waiting for sandbox to finish starting...', foundSandbox.id);
+                        console.info('Stopping %s was triggered. Waiting for sandbox to finish stopping...', foundSandbox.id);
                         waitForSandboxStatus(foundSandbox, SANDBOX_STATUS_DOWN);
                     }
                 });

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -46,6 +46,7 @@ const SANDBOX_WEBDAV_PERMISSIONS = [{ client_id: "CLIENTID",
 const SANDBOX_STATUS_POLL_TIMEOUT = 5000;
 const SANDBOX_STATUS_POLL_ERROR_THRESHOLD = 3;
 const SANDBOX_STATUS_UP_AND_RUNNING = 'started';
+const SANDBOX_STATUS_DOWN = 'stopped';
 const SANDBOX_STATUS_FAILED = 'failed';
 const BM_PATH = '/on/demandware.store/Sites-Site';
 const SANDBOX_RESOURCE_PROFILES = [ 'medium', 'large', 'xlarge' ];
@@ -74,41 +75,53 @@ function getAPIHost() {
 }
 
 /**
- * Utility function to poll getSandbox() until sandbox status is 'started'
+ * Utility function to wait for target sandbox to have a specific status. SetInterval calls
+ * internal getSandox() at the rate defined in SANDBOX_STATUS_POLL_TIMEOUT until the target
+ * status is found, or an error occurs.
  *
- * @param {Object} targetSandbox - the sandbox to target status checks for
+ * @param {Object} targetSandbox - sandbox to target status checks against
+ * @param {String} targetStatus - sandbox status to check for, e.g. started, stopped
  */
-function pollSandboxForStartedStatus(targetSandbox) {
+function waitForSandboxStatus(targetSandbox, targetStatus) {
 
-    // results
-    var result = [];
-    result['sandbox'] = targetSandbox;
-
-    // no failure
+    var errorThreshold = SANDBOX_STATUS_POLL_ERROR_THRESHOLD;
+    var startTime = Date.now();
     var finished = false;
     var fault = null;
 
-    // error threshold
-    var errorThreshold = SANDBOX_STATUS_POLL_ERROR_THRESHOLD;
-    var startTime = Date.now();
+    function pollSandbox() {
 
-    var timeout = setInterval(function() {
-        // poll the status
+        // check for auth token before anything
+        // ocapi.retryableCall will exit without a callback causing an infinite loop if auth expires
+        if (!auth.getToken()) {
+            clearInterval(timeout);
+            console.error('Authorization no longer valid. Please (re-)authenticate first by running ' +
+                '`sfcc-ci auth:login` or `sfcc-ci client:auth`');
+                return;
+        }
+
+        // in case we come back around
+        if (finished) {
+            clearInterval(timeout);
+            return;
+        }
+
+        // check if operation timeout has been exceeded
+        if ((Date.now() - startTime) > getSandboxAPIPollingTimeout()) {
+            // report an exceeded operation timeout
+            clearInterval(timeout);
+            console.error('Sandbox polling timeout has been exceeded.');
+            return;
+        }
+
         getSandbox(targetSandbox.id, null, function(err, sandbox) {
-
             // check if operation timeout has been exceeded
-            if ( Date.now() - startTime > getSandboxAPIPollingTimeout() ) {
-                // report an exceeded operation timeout
-                fault = {
-                    message : 'Sandbox polling timeout has been exceeded.'
-                };
-            } else if (err && errorThreshold > 0) {
-                console.error(err);
+            if (err && errorThreshold > 0) {
                 // in case status retrieval failed
                 // decrease the error threshold
                 errorThreshold--;
                 // don't set an error and allow the polling to continue
-                console.debug('Polling sandbox status failed. Polling error threshold not reached.');
+                console.debug('Polling sandbox status failed. Polling error threshold not reached. Continuing.');
             } else if (err && errorThreshold === 0) {
                 // report a reached error threshold during polling
                 fault = {
@@ -117,9 +130,11 @@ function pollSandboxForStartedStatus(targetSandbox) {
                 };
             } else if (!err) {
                 // update the status
-                if (sandbox && sandbox.state === SANDBOX_STATUS_UP_AND_RUNNING ) {
+                if (sandbox && sandbox.state === targetStatus) {
                     finished = true;
-                } else if (sandbox && sandbox.state === SANDBOX_STATUS_FAILED ) {
+                } else if (sandbox && sandbox.state === SANDBOX_STATUS_FAILED) {
+                    // if sandbox status is failed, we should exit
+                    finished = true;
                     // report a failed sandbox
                     fault = {
                         message : 'Sandbox has a `failed` status. Please investigate.'
@@ -133,31 +148,27 @@ function pollSandboxForStartedStatus(targetSandbox) {
             }
 
             // update duration
-            duration = Date.now() - startTime;
+            var duration = Date.now() - startTime;
 
-            // skip polling
+            // clear polling
             clearInterval(timeout);
 
+            // resturn result
             if (fault) {
                 // polling expired or sandbox state is failed
                 // treat this as error
-                result['error'] = fault.message;
+                console.error(fault.message);
             } else {
-                // TODO append message (e.g. from default set)
-                result['message'] = util.format('Starting of sandbox %s-%s finished (%s ms). ' +
-                    'Sandbox id is %s, status of sandbox is %s. You may use `sfcc-ci sandbox:list` to ' +
-                    'check the status of the sandbox.', result['sandbox'].realm, result['sandbox'].instance,
-                duration, result['sandbox'].id, result['sandbox'].state);
+                console.info(util.format('Sandbox %s-%s with ID %s, was found with status `%s` (%s ms).',
+                    sandbox.realm, sandbox.instance, sandbox.id, sandbox.state,duration));
+                console.info('You may use `sfcc-ci sandbox:list` to check the status of all sandboxes.');
             }
-
-            if (result['error']) {
-                console.error(result['error']);
-            }
-            // plain output
-            console.info(result['message']);
         });
-    }, SANDBOX_STATUS_POLL_TIMEOUT);
-
+    }
+    // setup recurring
+    var timeout = setInterval(pollSandbox, SANDBOX_STATUS_POLL_TIMEOUT);
+    // trigger immediately
+    pollSandbox();
 }
 
 /**
@@ -1361,7 +1372,7 @@ module.exports.cli = {
                 return;
             }
 
-            if ( !foundSandbox ) {
+            if (!foundSandbox) {
                 // no sandbox found
                 if (spec['realm'] && spec['instance']) {
                     console.error('Cannot find sandbox with realm %s and instance %s.', spec['realm'],
@@ -1382,8 +1393,8 @@ module.exports.cli = {
                         console.info('Starting %s triggered. You may use `sfcc-ci sandbox:list` to check the ' +
                             'status of the operation.', foundSandbox.id);
                     } else {
-                        console.info('Starting %s was triggered. Waiting for starting to complete...', foundSandbox.id);
-                        pollSandboxForStartedStatus(foundSandbox);
+                        console.info('Starting %s was triggered. Waiting for sandbox to finish starting...', foundSandbox.id);
+                        waitForSandboxStatus(foundSandbox, SANDBOX_STATUS_UP_AND_RUNNING);
                     }
                 });
             }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1441,8 +1441,13 @@ module.exports.cli = {
                         return;
                     }
 
-                    console.info('Stopping %s triggered. You may use `sfcc-ci sandbox:list` to check the ' +
+                    if (!sync) {
+                        console.info('Stopping %s triggered. You may use `sfcc-ci sandbox:list` to check the ' +
                         'status of the operation.', foundSandbox.id);
+                    } else {
+                        console.info('Stopping %s was triggered. Waiting for sandbox to finish starting...', foundSandbox.id);
+                        waitForSandboxStatus(foundSandbox, SANDBOX_STATUS_DOWN);
+                    }
                 });
             }
         });

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -74,6 +74,93 @@ function getAPIHost() {
 }
 
 /**
+ * Utility function to poll getSandbox() until sandbox status is 'started'
+ *
+ * @param {Object} targetSandbox - the sandbox to target status checks for
+ */
+function pollSandboxForStartedStatus(targetSandbox) {
+
+    // results
+    var result = [];
+    result['sandbox'] = targetSandbox;
+
+    // no failure
+    var finished = false;
+    var fault = null;
+
+    // error threshold
+    var errorThreshold = SANDBOX_STATUS_POLL_ERROR_THRESHOLD;
+    var startTime = Date.now();
+
+    var timeout = setInterval(function() {
+        // poll the status
+        getSandbox(targetSandbox.id, null, function(err, sandbox) {
+
+            // check if operation timeout has been exceeded
+            if ( Date.now() - startTime > getSandboxAPIPollingTimeout() ) {
+                // report an exceeded operation timeout
+                fault = {
+                    message : 'Sandbox polling timeout has been exceeded.'
+                };
+            } else if (err && errorThreshold > 0) {
+                console.error(err);
+                // in case status retrieval failed
+                // decrease the error threshold
+                errorThreshold--;
+                // don't set an error and allow the polling to continue
+                console.debug('Polling sandbox status failed. Polling error threshold not reached.');
+            } else if (err && errorThreshold === 0) {
+                // report a reached error threshold during polling
+                fault = {
+                    message : 'Polling sandbox status failed. Error threshold reached. Stop polling, ' +
+                        'the instantiating command may still be running. Detailed error was ' + err.message
+                };
+            } else if (!err) {
+                // update the status
+                if (sandbox && sandbox.state === SANDBOX_STATUS_UP_AND_RUNNING ) {
+                    finished = true;
+                } else if (sandbox && sandbox.state === SANDBOX_STATUS_FAILED ) {
+                    // report a failed sandbox
+                    fault = {
+                        message : 'Sandbox has a `failed` status. Please investigate.'
+                    };
+                }
+            }
+
+            if (!finished && !fault) {
+                // continue polling
+                return;
+            }
+
+            // update duration
+            duration = Date.now() - startTime;
+
+            // skip polling
+            clearInterval(timeout);
+
+            if (fault) {
+                // polling expired or sandbox state is failed
+                // treat this as error
+                result['error'] = fault.message;
+            } else {
+                // TODO append message (e.g. from default set)
+                result['message'] = util.format('Starting of sandbox %s-%s finished (%s ms). ' +
+                    'Sandbox id is %s, status of sandbox is %s. You may use `sfcc-ci sandbox:list` to ' +
+                    'check the status of the sandbox.', result['sandbox'].realm, result['sandbox'].instance,
+                duration, result['sandbox'].id, result['sandbox'].state);
+            }
+
+            if (result['error']) {
+                console.error(result['error']);
+            }
+            // plain output
+            console.info(result['message']);
+        });
+    }, SANDBOX_STATUS_POLL_TIMEOUT);
+
+}
+
+/**
  * Utility function to lookup the sandbox API polling timeout. By default it is defined as
  * SANDBOX_API_POLLING_TIMEOUT. The timeout can be overwritten using the environment
  * variable SFCC_SANDBOX_API_POLLING_TIMEOUT.
@@ -1266,13 +1353,15 @@ module.exports.cli = {
             return;
         }
 
-        // try to find the sandbox to remove
+        // try to find the sandbox to start
         lookupSandbox(spec, function(err, foundSandbox) {
             if (err) {
                 // error
                 console.error(err.message);
                 return;
-            } else if ( !foundSandbox ) {
+            }
+
+            if ( !foundSandbox ) {
                 // no sandbox found
                 if (spec['realm'] && spec['instance']) {
                     console.error('Cannot find sandbox with realm %s and instance %s.', spec['realm'],
@@ -1289,8 +1378,13 @@ module.exports.cli = {
                         return;
                     }
 
-                    console.info('Starting %s triggered. You may use `sfcc-ci sandbox:list` to check the ' +
-                        'status of the operation.', foundSandbox.id);
+                    if (!sync) {
+                        console.info('Starting %s triggered. You may use `sfcc-ci sandbox:list` to check the ' +
+                            'status of the operation.', foundSandbox.id);
+                    } else {
+                        console.info('Starting %s was triggered. Waiting for starting to complete...', foundSandbox.id);
+                        pollSandboxForStartedStatus(foundSandbox);
+                    }
                 });
             }
         });


### PR DESCRIPTION
Finishes adding in a `--sync` flag to sandbox:start and sandbox:stop

Used `-w` (for wait) as the shortcut since both `-s` was used for sandbox in this command, and `-c` for cartridge elsewhere. 

Created an additional utility function based on the sync method in sandbox:create. To keep scope small that was left alone and this was used for start and stop.