### PR TITLE
Update SLAS Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ Use `sfcc-ci --help` or just `sfcc-ci` to get started and see the full list of c
     user:create [options]                                           Create a new user
     user:update [options]                                           Update a user
     user:delete [options]                                           Delete a user
-    slas:tenant:list [options]                                      Lists all tenants that belong to a given organization
     slas:tenant:add [options]                                       Adds a SLAS tenant to a given organization or updates an existing one
     slas:tenant:get [options]                                       Gets a SLAS tenant from a given organization
     slas:tenant:delete [options]                                    Deletes a SLAS tenant from a given organization

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ You are now ready to use the tool by running the main command `sfcc-ci`.
 
 Use `sfcc-ci --help` or just `sfcc-ci` to get started and see the full list of commands available:
 
-```bash
+```txt
     Usage: cli [options] [command]
 
   Options:
@@ -334,15 +334,13 @@ Use `sfcc-ci --help` or just `sfcc-ci` to get started and see the full list of c
     user:create [options]                                           Create a new user
     user:update [options]                                           Update a user
     user:delete [options]                                           Delete a user
-    slas:tenant:add [options]                                       Adds a SLAS tenant to a given organization or updates an existing one
-    slas:tenant:get [options]                                       Gets a SLAS tenant from a given organization
-    slas:tenant:delete [options]                                    Deletes a SLAS tenant from a given organization
-    slas:client:add [options]                                       Adds a SLAS client to a given tenant or updates an existing one
-    slas:client:get [options]                                       Gets a SLAS client from a given tenant
-    slas:client:list [options]                                      Lists all SLAS clients that belong to a given tenant
-    slas:client:delete [options]                                    Deletes a SLAS client from a given tenant
-
-  Environment:
+    slas:tenant:add [options]                                       Add or update SLAS a tenant.
+    slas:tenant:get [options]                                       Get a SLAS tenant.
+    slas:client:add [options]                                       Add or update a SLAS client for a tenant
+    slas:client:get [options]                                       Get a SLAS client for a tenant.
+    slas:client:list [options]                                      List SLAS clients for a tenant.
+    slas:client:delete [options]                                    Delete a SLAS client for a tenant.
+    Environment:
 
     $SFCC_LOGIN_URL                    set login url used for authentication
     $SFCC_OAUTH_LOCAL_PORT             set Oauth local port for authentication flow
@@ -400,6 +398,8 @@ The use of environment variables is optional. `sfcc-ci` respects the following e
 * `SFCC_OAUTH_USER_PASSWORD` user password used for authentication
 * `SFCC_SANDBOX_API_HOST` set sandbox API host
 * `SFCC_SANDBOX_API_POLLING_TIMEOUT` set timeout for sandbox polling in minutes
+* `SFCC_SCAPI_SHORTCODE` the Salesforce Commerce (Headless) API Shortcode
+* `SFCC_SCAPI_TENANTID` the Salesforce Commerce (Headless) API TenantId
 * `DEBUG` enable verbose output
 
 If you only want a single CLI command to write debug messages prepend the command using, e.g. `DEBUG=* sfcc-ci <sub:command>`.
@@ -977,107 +977,70 @@ callback         | (Function)  | Callback function executed as a result. The err
 
 APIs available in `require('sfcc').slas`:
 
-`tenant.add(tenantId, shortcode, description, merchantName, contact, emailAddress, fileName)`
+`tenant.add({shortcode, tenant, file})`
 
-Adds the tenant details to the SLAS organization
+Add or update SLAS a tenant.
 
 Param         | Type        | Description
 ------------- | ------------| --------------------------------
-tenantId      | (String)    | The tenant ID
-shortcode     | (String)    | The short code of the org
-description   | (String)    | Description of the tenant
-merchantName  | (String)    | Name of the merchant
-contact       | (String)    | Username of the user
-emailAddress  | (String)    | Email address of the user
-fileName      | (String)    | Path of the file containing all the params required for the tenant creation.
+shortcode     | (String)    | Realm short code, `kv7kzm78`
+tenant        | (String)    | Tenant ID, `zzrf_001`
+file          | (String)    | Path to a JSON file with object details, `file.json`
 
 **Returns:** (Promise) The [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) with its `resolve` or `reject` methods called respectively with the `result` or the `error`. The `result` variable here is the newly created tenant reponse.
 
 ***
 
-`tenant.get(tenantId, shortcode)`
+`tenant.get({shortcode, tenant})`
 
-Gets the tenant matching the given `tenantId` for the given `shortCode`
+Get a SLAS tenant.
 
 Param         | Type        | Description
 ------------- | ------------| --------------------------------
-tenantId      | (String)    | The tenant ID
-shortcode     | (String)    | The short code of the org
+shortcode     | (String)    | Realm short code, `kv7kzm78`
+tenant        | (String)    | Tenant ID, `zzrf_001`
 
 **Returns:** (Promise) The [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) with its `resolve` or `reject` methods called respectively with the `result` or the `error`. The `result` variable here is the tenant reponse.
 
 ***
 
-`tenant.list(shortcode)`
+`client.add({shortcode, tenant, client, body})`
 
-Lists all the tenants for the given `shortCode`
-
-Param         | Type        | Description
-------------- | ------------| --------------------------------
-shortcode     | (String)    | The short code of the org
-
-**Returns:** (Promise) The [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) with its `resolve` or `reject` methods called respectively with the `result` or the `error`. The `result` variable here is list of tenants reponse.
-
-***
-
-`tenant.delete(tenantId, shortcode)`
-
-Deletes the tenant matching the given `tenantId` for the given `shortCode`
+Add or update a SLAS client for a tenant
 
 Param         | Type        | Description
 ------------- | ------------| --------------------------------
-tenantId      | (String)    | The tenant ID
-shortcode     | (String)    | The short code of the org
-
-**Returns:** (Promise) The [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) with its `resolve` or `reject` methods called respectively with the `result` or the `error`. The `result` variable here is the deletion reponse.
-
-***
-
-`client.add(tenantId, shortcode, file, clientid, clientname, privateclient, ecomtenant, ecomsite, secret, channels, scopes, redirecturis)`
-
-Registers a new client within a given tenant
-
-Param         | Type        | Description
-------------- | ------------| --------------------------------
-tenantId      | (String)    | The tenant ID
-shortcode     | (String)    | The short code of the org
-file          | (String)    | Path of the file containing all the params required for the client creation.
-clientid      | (String)    | SLAS client id
-clientname    | (String)    | The client name
-privateclient | (Boolean)   | Is the client a private client or not
-ecomtenant    | (String)    | The ecom tenant
-ecomsite      | (String)    | The ecom site
-secret        | (String)    | The secret tied to the client ID
-channels      | (Array)     | The list of channels for the client
-scopes        | (Array)     | The list of scopes authorized for the client
-redirecturis  | (Array)     | The list of redirect URIs authorized for the client
+shortcode     | (String)    | Realm short code, `kv7kzm78`
+tenant        | (String)    | Tenant ID, `zzrf_001`
+client        | (String)    | Client ID, `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`
+body          | (Object)    | Object with client's properties.
 
 **Returns:** (Promise) The [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) with its `resolve` or `reject` methods called respectively with the `result` or the `error`. The `result` variable here is the newly created client reponse.
 
 ***
 
-`client.get(tenantId, shortcode, clientId)`
+`client.get({shortcode, tenant, client})`
 
-Gets the tenant matching the given `clientid` for the given `tenantId` and `shortCode`
+Get a SLAS client for a tenant.
 
 Param         | Type        | Description
 ------------- | ------------| --------------------------------
-tenantId      | (String)    | The tenant ID
-shortcode     | (String)    | The short code of the org
-clientid      | (String)    | SLAS client id
+shortcode     | (String)    | Realm short code, `kv7kzm78`
+tenant        | (String)    | Tenant ID, `zzrf_001`
+client        | (String)    | Client ID, `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`
 
 **Returns:** (Promise) The [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) with its `resolve` or `reject` methods called respectively with the `result` or the `error`. The `result` variable here is the client reponse.
 
 ***
 
-`client.list(shortcode, tenantId)`
+`client.list({shortcode, tenantId})`
 
-Lists all the clients for the given `tenantId` and `shortCode`
+List SLAS clients for a tenant.
 
 Param         | Type        | Description
 ------------- | ------------| --------------------------------
-shortcode     | (String)    | The short code of the org
-tenantId      | (String)    | The tenant ID
+shortcode     | (String)    | Realm short code, `kv7kzm78`
+tenant        | (String)    | Tenant ID, `zzrf_001`
 
 **Returns:** (Promise) The [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) with its `resolve` or `reject` methods called respectively with the `result` or the `error`. The `result` variable here is list of clients reponse.
 
@@ -1085,13 +1048,13 @@ tenantId      | (String)    | The tenant ID
 
 `client.delete(tenantId, shortcode, clientId)`
 
-Deletes the client matching the given `clientId` for the given `tenantId` and `shortCode`
+Delete a SLAS client for a tenant.
 
 Param         | Type        | Description
 ------------- | ------------| --------------------------------
-tenantId      | (String)    | The tenant ID
-shortcode     | (String)    | The short code of the org
-clientid      | (String)    | SLAS client id
+shortcode     | (String)    | Realm short code, `kv7kzm78`
+tenant        | (String)    | Tenant ID, `zzrf_001`
+client        | (String)    | Client ID, `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`
 
 **Returns:** (Promise) The [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) with its `resolve` or `reject` methods called respectively with the `result` or the `error`. The `result` variable here is the deletion reponse.
 

--- a/cli.js
+++ b/cli.js
@@ -1944,124 +1944,112 @@ program
         console.log();
     });
 
+const SLAS_OPTIONS = {
+    'shortcode': ['--shortcode <shortcode>', 'Realm short code, `kv7kzm78`'],
+    'tenant': ['--tenant <tenant>', 'Tenant ID, `zzrf_001`'],
+    'client': ['--client <client>', 'Client ID, `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`'],
+    'file': ['--file <file>', 'Path to a JSON file with object details, `file.json`'],
+    'json': ['-j, --json', 'Format output in json', false]
+}
+
 program
     .command('slas:tenant:add')
-    .description('Add or update SLAS tenant')
-    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
-    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
-    .option('--file <file>', 'Optional path to JSON file with tenant details')
-    .option('-j, --json', 'Format output in json', false)
+    .description('Add or update SLAS a tenant.')
+    .option(...SLAS_OPTIONS.shortcode)
+    .option(...SLAS_OPTIONS.tenant)
+    .option(...SLAS_OPTIONS.file)
+    .option(...SLAS_OPTIONS.json)
     .action(async (options) => {
         await require('./lib/slas').cli.tenant.add(options);
     })
     .on('--help', () => {
         console.log();
+        console.log('  Examples:');
+        console.log();
+        console.log('    $ sfcc-ci slas:tenant:create --shortcode kv7kzm78 --tenant zzrf_001');
+        console.log('    $ sfcc-ci slas:tenant:create --shortcode kv7kzm78 --tenant zzrf_001 --file tenant.json');
+        console.log();
     });
 
 program
     .command('slas:tenant:get')
-    .description('Retrive SLAS tenant')
-    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
-    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
-    .option('-j, --json', 'Format output in json', false)
+    .description('Get a SLAS tenant.')
+    .option(...SLAS_OPTIONS.shortcode)
+    .option(...SLAS_OPTIONS.tenant)
+    .option(...SLAS_OPTIONS.json)
     .action(async (options) => {
         await require('./lib/slas').cli.tenant.get(options);
     })
     .on('--help', () => {
         console.log();
-    });
-
-program
-    .command('slas:tenant:delete')
-    .description('Remove SLAS tenant')
-    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
-    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
-    .option('-j, --json', 'Format output in json', false)
-    .action(async (options) => {
-        await require('./lib/slas').cli.tenant.delete(options);
-    })
-    .on('--help', () => {
+        console.log('  Examples:');
+        console.log();
+        console.log('    $ sfcc-ci slas:tenant:get --shortcode kv7kzm78 --tenant zzrf_001');
         console.log();
     });
 
 program
     .command('slas:client:add')
-    .description('Add or update SLAS client for a tenant')
-    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
-    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
-    .option('--file <file>', 'Optional path to JSON file with client details.')
-    .option('--client <client>', 'Client ID, eg. `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
-    .option('--clientname <clientname>', 'The name of the client ID')
-    .option('--privateclient <privateclient>', 'true the client is private')
-    .option('--ecomtenant <ecomtenant>', 'the ecom tenant')
-    .option('--ecomsite <ecomsite>', 'the ecom site')
-    .option('--secret <secret>', 'the slas secret, can be different then the secret in \
-        account manager, but shouldnt be')
-    .option('--channels <channels>', 'comma separated list of site IDs this API client should support')
-    .option('--scopes <scopes>', 'comma separated list of auth z scopes this API client should support')
-    .option('--redirecturis <redirecturis>', 'comma separated list of redirect uris this API client should support')
-
-    .option('-j, --json', 'Formats the output in json')
-    .action(async function(options) {
-
-        var asJson = ( options.json ? options.json : false );
-        const clientid = options.clientid;
-        const clientname = options.clientname;
-        const privateclient = options.privateclient;
-        const ecomtenant = options.ecomtenant;
-        const ecomsite = options.ecomsite;
-        const secret = options.secret;
-        const channels = !options.channels || options.channels.split(',').map(item => item.trim());
-        const scopes = !options.scopes || options.scopes.split(',').map(item => item.trim());
-        const redirecturis = !options.redirecturis || options.redirecturis.split(',').map(item => item.trim());
-
-        const slas = require('./lib/slas');
-        await slas.cli.client.add(options.tenant, options.shortcode, options.file,
-            clientid, clientname, privateclient, ecomtenant, ecomsite, secret, channels, scopes, redirecturis, asJson);
-
+    .description('Add or update a SLAS client for a tenant.')
+    .option(...SLAS_OPTIONS.shortcode)
+    .option(...SLAS_OPTIONS.tenant)
+    .option(...SLAS_OPTIONS.client)
+    .option(...SLAS_OPTIONS.file)
+    .action(async (options) => {
+        await require('./lib/slas').cli.client.add(options);
     }).on('--help', function() {
+        console.log();
+        console.log('  Examples:');
+        console.log();
+        console.log('    $ sfcc-ci slas:client:add --shortcode kv7kzm78 --tenant zzrf_001 --client aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa --file client.json');
         console.log();
     });
 
 program
     .command('slas:client:get')
-    .description('Gets a SLAS client from a given tenant')
-    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
-    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
-    .option('--client <client>', 'Client ID, eg. `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    .description('Get a SLAS client for a tenant.')
+    .option(...SLAS_OPTIONS.shortcode)
+    .option(...SLAS_OPTIONS.tenant)
+    .option(...SLAS_OPTIONS.client)
     .action(async (options) => {
         await require('./lib/slas').cli.client.get(options);
     }).on('--help', function() {
+        console.log();
+        console.log('  Examples:');
+        console.log();
+        console.log('    $ sfcc-ci slas:client:get --shortcode kv7kzm78 --tenant zzrf_001 --client aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
         console.log();
     });
 
 program
     .command('slas:client:list')
-    .description('List SLAS clients for a tenant')
-    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
-    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
+    .description('List SLAS clients for a tenant.')
+    .option(...SLAS_OPTIONS.shortcode)
+    .option(...SLAS_OPTIONS.tenant)
     .action(async (options) => {
         await require('./lib/slas').cli.client.list(options);
     })
     .on('--help', async () => {
         console.log();
+        console.log('  Examples:');
+        console.log();
+        console.log('    $ sfcc-ci slas:client:list --shortcode kv7kzm78 --tenant zzrf_001');
+        console.log();
     });
 
 program
     .command('slas:client:delete')
-    .description('Deletes a SLAS client from a given tenant')
-    .option('--tenant <tenant>', 'the tenant id used for slas')
-    .option('--shortcode <shortcode>', 'the organizations short code')
-    .option('--clientid <clientid>', 'The Client ID to delete')
-    .option('-j, --json', 'Formats the output in json')
+    .description('Delete a SLAS client for a tenant.')
+    .option(...SLAS_OPTIONS.shortcode)
+    .option(...SLAS_OPTIONS.tenant)
+    .option(...SLAS_OPTIONS.client)
     .action(async function(options) {
-
-        var asJson = ( options.json ? options.json : false );
-
-        const slas = require('./lib/slas');
-        await slas.cli.client.get(options.tenant, options.shortcode, options.clientid, asJson);
-
+        await require('./lib/slas').cli.client.delete(options);
     }).on('--help', function() {
+        console.log();
+        console.log('  Examples:');
+        console.log();
+        console.log('    $ sfcc-ci slas:client:delete --shortcode kv7kzm78 --tenant zzrf_001 --client aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
         console.log();
     });
 

--- a/cli.js
+++ b/cli.js
@@ -1946,63 +1946,51 @@ program
 
 program
     .command('slas:tenant:add')
-    .description('Add or update a SLAS tenant')
-    .option('--shortcode <shortcode>', 'the organization\'s short code')
-    .option('--tenant <tenant>', 'the tenant id used')
-    .option('--file <file>', 'JSON file with tenant details')
-    .option('--merchantname <merchantname>', 'the name given for the tenant')
-    .option('--tenantdescription <tenantdescription>', 'the tenant descriptions')
-    .option('--contact <contact>', 'Contact person to manage tenants')
-    .option('--email <email>', 'Email to contact')
-    .option('-j, --json', 'Formats the output in json', false)
+    .description('Add or update SLAS tenant')
+    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
+    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
+    .option('--file <file>', 'Optional path to JSON file with tenant details')
+    .option('-j, --json', 'Format output in json', false)
     .action(async (options) => {
-        await require('./lib/slas').cli.tenant.add(options)
+        await require('./lib/slas').cli.tenant.add(options);
     })
-    .on('--help', function() {
+    .on('--help', () => {
         console.log();
     });
 
 program
     .command('slas:tenant:get')
-    .description('Gets a SLAS tenant from a given organization')
-    .option('--tenant <tenant>', 'the tenant id used for slas')
-    .option('--shortcode <shortcode>', 'the organizations short code')
-    .option('-j, --json', 'Formats the output in json')
-    .action(async function(options) {
-
-        var asJson = ( options.json ? options.json : false );
-
-        const slas = require('./lib/slas');
-        await slas.cli.tenant.get(options.tenant, options.shortcode, asJson);
-
-    }).on('--help', function() {
+    .description('Retrive SLAS tenant')
+    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
+    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
+    .option('-j, --json', 'Format output in json', false)
+    .action(async (options) => {
+        await require('./lib/slas').cli.tenant.get(options);
+    })
+    .on('--help', () => {
         console.log();
     });
 
 program
     .command('slas:tenant:delete')
-    .description('Deletes a SLAS tenant from a given organization')
-    .option('--tenant <tenant>', 'the tenant id used for slas')
-    .option('--shortcode <shortcode>', 'the organizations short code')
-    .option('-j, --json', 'Formats the output in json')
-    .action(async function(options) {
-
-        var asJson = ( options.json ? options.json : false );
-
-        const slas = require('./lib/slas');
-        await slas.cli.tenant.get(options.tenant, options.shortcode, asJson);
-
-    }).on('--help', function() {
+    .description('Remove SLAS tenant')
+    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
+    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
+    .option('-j, --json', 'Format output in json', false)
+    .action(async (options) => {
+        await require('./lib/slas').cli.tenant.delete(options);
+    })
+    .on('--help', () => {
         console.log();
     });
 
 program
     .command('slas:client:add')
-    .description('Adds a SLAS client to a given tenant or updates an existing one')
-    .option('--tenant <tenant>', 'the tenant id used for slas')
-    .option('--shortcode <shortcode>', 'the organizations short code')
-    .option('--file <file>', 'The JSON File used to set up the slas client')
-    .option('--clientid <clientid>', 'The client ID to add')
+    .description('Add or update SLAS client for a tenant')
+    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
+    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
+    .option('--file <file>', 'Optional path to JSON file with client details.')
+    .option('--client <client>', 'Client ID, eg. `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
     .option('--clientname <clientname>', 'The name of the client ID')
     .option('--privateclient <privateclient>', 'true the client is private')
     .option('--ecomtenant <ecomtenant>', 'the ecom tenant')
@@ -2038,35 +2026,24 @@ program
 program
     .command('slas:client:get')
     .description('Gets a SLAS client from a given tenant')
-    .option('--tenant <tenant>', 'the tenant id used for slas')
-    .option('--shortcode <shortcode>', 'the organizations short code')
-    .option('--clientid <clientid>', 'The client ID to get information for')
-    .option('-j, --json', 'Formats the output in json')
-    .action(async function(options) {
-
-        var asJson = ( options.json ? options.json : false );
-
-        const slas = require('./lib/slas');
-        await slas.cli.client.get(options.tenant, options.shortcode, options.clientid, asJson);
-
+    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
+    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
+    .option('--client <client>', 'Client ID, eg. `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    .action(async (options) => {
+        await require('./lib/slas').cli.client.get(options);
     }).on('--help', function() {
         console.log();
     });
 
 program
     .command('slas:client:list')
-    .description('Lists all SLAS clients that belong to a given tenant')
-    .option('--tenant <tenant>', 'the tenant id used for slas')
-    .option('--shortcode <shortcode>', 'the organizations short code')
-    .option('-j, --json', 'Formats the output in json')
-    .action(async function(options) {
-
-        var asJson = ( options.json ? options.json : false );
-
-        const slas = require('./lib/slas');
-        await slas.cli.client.list(options.tenant, options.shortcode, asJson);
-
-    }).on('--help', function() {
+    .description('List SLAS clients for a tenant')
+    .option('--shortcode <shortcode>', 'Realm short code eg. `kv7kzm78`')
+    .option('--tenant <tenant>', 'Tenant ID eg. `zzrf_001`')
+    .action(async (options) => {
+        await require('./lib/slas').cli.client.list(options);
+    })
+    .on('--help', async () => {
         console.log();
     });
 

--- a/cli.js
+++ b/cli.js
@@ -1946,24 +1946,19 @@ program
 
 program
     .command('slas:tenant:add')
-    .description('Adds a SLAS tenant to a given organization or updates an existing one')
-    .option('--tenant <tenant>', 'the tenant id used for slas')
-    .option('--shortcode <shortcode>', 'the organizations short code')
+    .description('Add or update a SLAS tenant')
+    .option('--shortcode <shortcode>', 'the organization\'s short code')
+    .option('--tenant <tenant>', 'the tenant id used')
     .option('--file <file>', 'JSON file with tenant details')
-    .option('--merchantname <merchantame>', 'the name given for the tenant')
+    .option('--merchantname <merchantname>', 'the name given for the tenant')
     .option('--tenantdescription <tenantdescription>', 'the tenant descriptions')
     .option('--contact <contact>', 'Contact person to manage tenants')
     .option('--email <email>', 'Email to contact')
-    .option('-j, --json', 'Formats the output in json')
-    .action(async function(options) {
-
-        var asJson = ( options.json ? options.json : false );
-
-        const slas = require('./lib/slas');
-        await slas.cli.tenant.add(options.tenant, options.shortcode,
-            options.tenantdescription, options.merchantname, options.contact, options.email, options.file, asJson);
-
-    }).on('--help', function() {
+    .option('-j, --json', 'Formats the output in json', false)
+    .action(async (options) => {
+        await require('./lib/slas').cli.tenant.add(options)
+    })
+    .on('--help', function() {
         console.log();
     });
 

--- a/cli.js
+++ b/cli.js
@@ -1944,23 +1944,6 @@ program
         console.log();
     });
 
-
-program
-    .command('slas:tenant:list')
-    .description('Lists all tenants that belong to a given organization')
-    .option('--shortcode <shortcode>', 'the organizations short code')
-    .option('-j, --json', 'Formats the output in json')
-    .action(async function(options) {
-
-        var asJson = ( options.json ? options.json : false );
-
-        const slas = require('./lib/slas');
-        await slas.cli.tenant.list(options.shortcode, asJson);
-
-    }).on('--help', function() {
-        console.log();
-    });
-
 program
     .command('slas:tenant:add')
     .description('Adds a SLAS tenant to a given organization or updates an existing one')

--- a/lib/slas.js
+++ b/lib/slas.js
@@ -1,8 +1,10 @@
 const fetch = require('node-fetch');
 const fs = require('fs');
+const jsonwebtoken = require('jsonwebtoken');
 
 const auth = require('./auth');
 const secrets = require('./secrets');
+
 
 /**
  *  Generates a SLAS Admin Url
@@ -22,12 +24,13 @@ function getSlasUrl(tenantId, shortcode, clientId) {
  *  @return {object} the parsed success response
  */
 async function handleResponse(response) {
-    if (response.status > 299) {
+    if (!response.ok) {
+        console.error(await response.text());
         throw new Error(`HTTP Fault ${response.status} (${response.statusText})`)
     }
 
-    const resultText = await response.text();
-    return JSON.parse(resultText);
+    const data = await response.json();
+    return data;
 }
 
 /**
@@ -59,15 +62,14 @@ function handleCLIError(prefix, message, asJson) {
 const slas = {
     cli: {
         tenant : {
-            add: async (tenantId, shortcode, description, merchantName, contact, emailAddress, fileName, asJson) => {
+            add: async ({shortcode, tenant: instance, tenantdescription: description, merchantName, contact, emailAddress, file, json}) => {
                 let result
                 try {
-                    result = await slas.api.tenant.add(tenantId, shortcode,
-                        description, merchantName, contact, emailAddress, fileName)
-                    console.info('sucessfully add tenant')
-                    handleCLIOutput(result, asJson)
+                    result = await slas.api.tenant.add({shortcode, instance, description, merchantName, contact, emailAddress, file})
+                    console.info('Successfully added tenant')
+                    handleCLIOutput(result, json)
                 } catch (e) {
-                    handleCLIError('Could not add tenant: ', e.message, asJson)
+                    handleCLIError('Could not add tenant: ', e.message, json)
                 }
             },
             get: async (tenantId, shortcode, asJson) => {
@@ -137,38 +139,43 @@ const slas = {
     },
     api: {
         tenant: {
-            add: async (tenantId, shortcode, description, merchantName, contact, emailAddress, fileName) => {
+            add: async ({shortcode, instance, description, merchantName, contact, emailAddress, file}) => {
                 const token = auth.getToken();
-                let params
-                // set fallbacks
+                const userEmail = jsonwebtoken.decode(token).sub
+                
                 shortcode = secrets.getScapiShortCode(shortcode);
-                if (!fileName) {
-                    tenantId = secrets.getScapiTenantId(tenantId);
-                    description = description || `Added by SFCC-CI at ${(new Date()).toISOString()}`
-                    merchantName = merchantName || tenantId
-                    contact = contact || auth.getUser()
-                    emailAddress = emailAddress || (auth.getUser() ? auth.getUser() : 'noreply@salesforce.com')
 
-                    params = {
-                        instance: tenantId,
+                let body
+                if (!file) {
+                    instance = secrets.getScapiTenantId(instance);
+                    description = description || `Added by SFCC-CI at ${(new Date()).toISOString()}`
+                    contact = contact || auth.getUser() || userEmail
+                    emailAddress = emailAddress || auth.getUser() || userEmail
+
+                    body = {
+                        instance,
                         description,
                         merchantName,
                         contact,
                         emailAddress
                     }
                 } else {
-                    params = JSON.parse(fs.readFileSync(fileName, 'utf-8'));
-                    tenantId = secrets.getScapiTenantId(tenantId || params.instance);
+                    body = JSON.parse(fs.readFileSync(file, 'utf-8'));
+                    console.log({body})
+                    instance = secrets.getScapiTenantId(instance || body.instance);
                 }
-                const response = await fetch(getSlasUrl(tenantId, shortcode), {
+
+                const url = getSlasUrl(instance, shortcode)
+                const options = {
                     method: 'PUT',
                     headers: {
                         'Authorization': `Bearer ${token}`,
                         'Content-Type': 'application/json'
                     },
-                    body: JSON.stringify(params)
-                });
+                    body: JSON.stringify(body)
+                }
 
+                const response = await fetch(url, options);
                 return await handleResponse(response);
             },
             get: async (tenantId, shortcode) => {

--- a/lib/slas.js
+++ b/lib/slas.js
@@ -79,15 +79,6 @@ const slas = {
                     handleCLIError('Could not get tenant: ', e.message, asJson)
                 }
             },
-            list: async (shortcode, asJson) => {
-                let result
-                try {
-                    result = await slas.api.tenant.list(shortcode)
-                    handleCLIOutput(result, asJson)
-                } catch (e) {
-                    handleCLIError('Could not get tenants: ', e.message, asJson)
-                }
-            },
             delete: async (tenantId, shortcode, asJson) => {
                 let result
                 try {
@@ -195,22 +186,6 @@ const slas = {
                     }
                 });
 
-                return await handleResponse(response);
-            },
-            list: async (shortcode) => {
-                const token = auth.getToken();
-
-                // set fallbacks
-                tenantId = secrets.getScapiTenantId(tenantId);
-                shortcode = secrets.getScapiShortCode(shortcode);
-
-                const response = await fetch(getSlasUrl('', shortcode), {
-                    method: 'GET',
-                    headers: {
-                        'Authorization': `Bearer ${token}`,
-                        'Content-Type': 'application/json'
-                    }
-                });
                 return await handleResponse(response);
             },
             delete: async (tenantId, shortcode) => {

--- a/lib/slas.js
+++ b/lib/slas.js
@@ -12,19 +12,10 @@ const secrets = require('./secrets');
  *  @param {string} shortcode the shortcode found in BM - e.g acdefg
   * @param {string} [clientId] if provided a client URL is generated
  */
-function getSlasUrl(tenantId, shortcode, clientId) {
-    const bits = [
-        `https://${shortcode}.api.commercecloud.salesforce.com/shopper/auth-admin/v1/tenants`
-    ]
-    
-    if (tenantId) {
-        bits.push(tenantId);
-    }
-
-    if (clientId) {
-        bits.push(`clients/${clientId}`);
-    }
-
+function getSlasUrl({shortcode, tenant, client}) {
+    const bits = [`https://${shortcode}.api.commercecloud.salesforce.com/shopper/auth-admin/v1/tenants`]
+    tenant && bits.push(tenant);
+    client && bits.push(`clients/${client}`);
     return bits.join('/')
 }
 
@@ -76,13 +67,21 @@ function handleCLIError(prefix, message, asJson) {
     }
 }
 
-
+async function read(stream) {
+    const chunks = [];
+    for await (const chunk of stream) chunks.push(chunk);
+    return Buffer.concat(chunks).toString("utf8");
+}
+  
 const slas = {
     cli: {
         tenant : {
-            add: async ({shortcode, tenant: instance, tenantdescription: description, merchantName, contact, emailAddress, file, json}) => {
+            add: async ({shortcode, tenant, file, json}) => {
+                shortcode = secrets.getScapiShortCode(shortcode);
+                tenant = secrets.getScapiTenantId(tenant);
+
                 try {
-                    const result = await slas.api.tenant.add({shortcode, instance, description, merchantName, contact, emailAddress, file})
+                    const result = await slas.api.tenant.add({shortcode, tenant, file})
                     console.info('Successfully added tenant')
                     handleCLIOutput(result, json)
                 } catch (e) {
@@ -90,45 +89,54 @@ const slas = {
                 }
             },
             get: async ({shortcode, tenant, json}) => {
+                shortcode = secrets.getScapiShortCode(shortcode);
+                tenant = secrets.getScapiTenantId(tenant);
+
                 try {
                     const result = await slas.api.tenant.get({shortcode, tenant})
                     handleCLIOutput(result, json)
                 } catch (e) {
                     handleCLIError('Could not get tenant: ', e.message, json)
                 }
-            },
-            delete: async (tenantId, shortcode, asJson) => {
-                let result
-                try {
-                    result = await slas.api.tenant.delete(tenantId, shortcode)
-                    handleCLIOutput(result, asJson)
-                } catch (e) {
-                    handleCLIError('Could not delete tenant: ', e.message, asJson)
-                }
             }
         },
         client : {
-            add: async (tenantId, shortcode, fileName,clientid, clientname, privateclient,
-                ecomtenant, ecomsite, secret, channels, scopes, redirecturis, asJson) => {
-                let result
+            add: async ({shortcode, tenant, client, file}) => {
+                if (!file) {
+                    throw new Error('Option --file is required.');
+                }
+                
+                shortcode = secrets.getScapiShortCode(shortcode);
+                tenant = secrets.getScapiTenantId(tenant);
+
+                // Ensure `file` is valid JSON.
+                const body = JSON.parse(fs.readFileSync(file, 'utf-8'));
+                // Provided Client ID overrides JSON.
+                body.clientId = client
+
                 try {
-                    result = await slas.api.client.add(tenantId, shortcode, fileName, clientid, clientname,
-                        privateclient, ecomtenant, ecomsite, secret, channels, scopes, redirecturis);
-                    console.info('sucessfully add client ')
-                    handleCLIOutput(result, asJson)
+                    const result = await slas.api.client.add({shortcode, tenant, client, body});
+                    console.info('Successfully added client')
+                    handleCLIOutput(result, true)
                 } catch (e) {
-                    handleCLIError('Could not add client: ', e.message, asJson)
+                    handleCLIError('Could not add client: ', e.message, true)
                 }
             },
             get: async ({shortcode, tenant, client}) => {
+                shortcode = secrets.getScapiShortCode(shortcode);
+                tenant = secrets.getScapiTenantId(tenant);
+
                 try {
                     const result = await slas.api.client.get({shortcode, tenant, client})
-                    console.dir(result)
+                    console.log(JSON.stringify(result, null, 4))
                 } catch (e) {
                     handleCLIError('Could not get client: ', e.message)
                 }
             },
             list: async ({shortcode, tenant}) => {
+                shortcode = secrets.getScapiShortCode(shortcode);
+                tenantId = secrets.getScapiTenantId(tenant);
+
                 try {
                     const result = await slas.api.client.list({shortcode, tenant});
                     console.dir(result, {depth: null});
@@ -136,38 +144,39 @@ const slas = {
                     handleCLIError('Could not list clients: ', e.message)
                 }
             },
-            delete: async (tenantId, shortcode, clientId, asJson) => {
-                let result
+            delete: async ({shortcode, tenant, client}) => {
+                shortcode = secrets.getScapiShortCode(shortcode);
+                tenant = secrets.getScapiTenantId(tenant);
+
                 try {
-                    result = await slas.api.client.delete(tenantId, shortcode, clientId)
-                    handleCLIOutput(result, asJson)
+                    const result = await slas.api.client.delete({shortcode, tenant, client})
+                    handleCLIOutput(result, true)
                 } catch (e) {
-                    handleCLIError('Could not delete tenant: ', e.message, asJson)
+                    handleCLIError('Could not delete tenant: ', e.message, true)
                 }
             }
         }
     },
     api: {
         tenant: {
-            add: async ({shortcode, instance, file}) => {
+            add: async ({shortcode, tenant, file}) => {
                 const token = auth.getToken();
-
-                shortcode = secrets.getScapiShortCode(shortcode);
 
                 let body
                 if (!file) {
-                    instance = secrets.getScapiTenantId(instance);
                     body = {
-                        instance,
+                        instance: tenant,
                         description: `Added by SFCC-CI at ${(new Date()).toISOString()}`,
-                        emailAddress: jsonwebtoken.decode(token).sub
+                        emailAddress: jsonwebtoken.decode(token).sub,
+                        merchantName: '_'
                     }
                 } else {
                     body = JSON.parse(fs.readFileSync(file, 'utf-8'));
-                    instance = secrets.getScapiTenantId(instance || body.instance);
+                    // Provided `tenant` overrides `instance` from JSON.
+                    body.instance = tenant
                 }
 
-                const url = getSlasUrl(instance, shortcode)
+                const url = getSlasUrl({shortcode, tenant})
                 const options = {
                     method: 'PUT',
                     headers: {
@@ -181,10 +190,7 @@ const slas = {
                 return await handleResponse(response);
             },
             get: async ({shortcode, tenant}) => {
-                shortcode = secrets.getScapiShortCode(shortcode);
-                tenant = secrets.getScapiTenantId(tenant);
-
-                const url = getSlasUrl(tenant, shortcode)
+                const url = getSlasUrl({tenant, shortcode})
                 const options = {
                     method: 'GET',
                     headers: {
@@ -195,62 +201,23 @@ const slas = {
                 const response = await fetch(url, options);
                 return await handleResponse(response);
             },
-            delete: async ({shortcode, tenant}) => {
-                shortcode = secrets.getScapiShortCode(shortcode);
-                tenant = secrets.getScapiTenantId(tenant);
-
-                const url = getSlasUrl(tenantId, shortcode);
+        },
+        client: {
+            add: async ({shortcode, tenant, client, body}) => {
+                const url = getSlasUrl({shortcode, tenant, client})
                 const options = {
-                    method: 'DELETE',
+                    method: 'PUT',
                     headers: {
-                        'Authorization': `Bearer ${await auth.getToken()}`,
+                        'Authorization': `Bearer ${auth.getToken()}`,
                         'Content-Type': 'application/json'
-                    }
+                    },
+                    body: JSON.stringify(body)
                 }
                 const response = await fetch(url, options);
                 return await handleResponse(response);
             },
-        },
-        client: {
-            add: async (tenantId, shortcode, file, clientid, clientname, privateclient,
-                ecomtenant, ecomsite, secret, channels, scopes, redirecturis,) => {
-                const token = auth.getToken();
-
-                // set fallbacks
-                shortcode = secrets.getScapiShortCode(shortcode);
-                let params;
-                if (file) {
-                    params = JSON.parse(fs.readFileSync(file, 'utf-8'));
-                } else {
-                    params = {
-                        cliendId: clientid,
-                        name: clientname,
-                        isPrivateClient: privateclient,
-                        ecomTenant: ecomtenant,
-                        ecomSite: ecomsite,
-                        secret: secret,
-                        channels: channels,
-                        scopes: scopes,
-                        redirectUri: redirecturis
-                    }
-                }
-                tenantId = secrets.getScapiTenantId(tenantId || params.ecomTenant);
-                const response = await fetch(getSlasUrl(tenantId, shortcode, params.clientId), {
-                    method: 'PUT',
-                    headers: {
-                        'Authorization': `Bearer ${token}`,
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify(params)
-                });
-
-                return await handleResponse(response);
-            },
             get: async ({shortcode, tenant, client}) => {
-                tenant = secrets.getScapiTenantId(tenant);
-                client = secrets.getScapiShortCode(client);
-
-                const url = getSlasUrl(tenant, shortcode, client);
+                const url = getSlasUrl({shortcode, tenant, client});
                 const options = {
                     headers: {
                         'Authorization': `Bearer ${auth.getToken()}`,
@@ -261,34 +228,27 @@ const slas = {
                 return await handleResponse(response);
             },
             list: async ({shortcode, tenant}) => {
-                shortcode = secrets.getScapiShortCode(shortcode);
-                tenantId = secrets.getScapiTenantId(tenant);
-
-                const url = getSlasUrl(tenant, shortcode) + '/clients'
+                const url = getSlasUrl({tenant, shortcode}) + '/clients'
                 const options = {
                     headers: {
                         'Authorization': `Bearer ${auth.getToken()}`,
                         'Content-Type': 'application/json'
                     }
                 }
+                // TODO: If no clients belong to this tenant, SLAS returns a HTTP 404.
                 const response = await fetch(url, options);
                 return await handleResponse(response);
             },
-            delete: async (tenantId, shortcode, clientId) => {
-                const token = auth.getToken();
-
-                // set fallbacks
-                tenantId = secrets.getScapiTenantId(tenantId);
-                shortcode = secrets.getScapiShortCode(shortcode);
-
-                const response = await fetch(getSlasUrl(tenantId, shortcode, clientId), {
+            delete: async ({shortcode, tenant, client}) => {
+                const url = getSlasUrl({shortcode, tenant, client});
+                const options = {
                     method: 'DELETE',
                     headers: {
-                        'Authorization': `Bearer ${token}`,
+                        'Authorization': `Bearer ${auth.getToken()}`,
                         'Content-Type': 'application/json'
                     }
-                });
-
+                };
+                const response = await fetch(url, options);
                 return await handleResponse(response);
             },
         }

--- a/lib/slas.js
+++ b/lib/slas.js
@@ -13,8 +13,19 @@ const secrets = require('./secrets');
   * @param {string} [clientId] if provided a client URL is generated
  */
 function getSlasUrl(tenantId, shortcode, clientId) {
-    return `https://${shortcode}.api.commercecloud.salesforce.com/shopper/auth-admin/v1/tenants/${tenantId
-        + (clientId ? ('/clients/' + clientId) : '')}`;
+    const bits = [
+        `https://${shortcode}.api.commercecloud.salesforce.com/shopper/auth-admin/v1/tenants`
+    ]
+    
+    if (tenantId) {
+        bits.push(tenantId);
+    }
+
+    if (clientId) {
+        bits.push(`clients/${clientId}`);
+    }
+
+    return bits.join('/')
 }
 
 
@@ -24,13 +35,20 @@ function getSlasUrl(tenantId, shortcode, clientId) {
  *  @return {object} the parsed success response
  */
 async function handleResponse(response) {
-    if (!response.ok) {
-        console.error(await response.text());
-        throw new Error(`HTTP Fault ${response.status} (${response.statusText})`)
+    if (response.ok) {
+        return await response.json();
     }
 
-    const data = await response.json();
-    return data;
+    const contentType = response.headers.get('content-type');
+    const isJSON = contentType && contentType.includes('application/json')
+    let message;
+    if (isJSON) {
+        message = await response.json();
+    } else {
+        message = await response.text();
+    }
+    console.error(message);
+    throw new Error(`HTTP Fault ${response.status} (${response.statusText})`);
 }
 
 /**
@@ -63,22 +81,20 @@ const slas = {
     cli: {
         tenant : {
             add: async ({shortcode, tenant: instance, tenantdescription: description, merchantName, contact, emailAddress, file, json}) => {
-                let result
                 try {
-                    result = await slas.api.tenant.add({shortcode, instance, description, merchantName, contact, emailAddress, file})
+                    const result = await slas.api.tenant.add({shortcode, instance, description, merchantName, contact, emailAddress, file})
                     console.info('Successfully added tenant')
                     handleCLIOutput(result, json)
                 } catch (e) {
                     handleCLIError('Could not add tenant: ', e.message, json)
                 }
             },
-            get: async (tenantId, shortcode, asJson) => {
-                let result
+            get: async ({shortcode, tenant, json}) => {
                 try {
-                    result = await slas.api.tenant.get(tenantId, shortcode)
-                    handleCLIOutput(result, asJson)
+                    const result = await slas.api.tenant.get({shortcode, tenant})
+                    handleCLIOutput(result, json)
                 } catch (e) {
-                    handleCLIError('Could not get tenant: ', e.message, asJson)
+                    handleCLIError('Could not get tenant: ', e.message, json)
                 }
             },
             delete: async (tenantId, shortcode, asJson) => {
@@ -104,26 +120,20 @@ const slas = {
                     handleCLIError('Could not add client: ', e.message, asJson)
                 }
             },
-            get: async (tenantId, shortcode, clientId, asJson) => {
-                let result
+            get: async ({shortcode, tenant, client}) => {
                 try {
-                    result = await slas.api.client.get(tenantId, shortcode, clientId)
-                    handleCLIOutput(result, asJson)
+                    const result = await slas.api.client.get({shortcode, tenant, client})
+                    console.dir(result)
                 } catch (e) {
-                    handleCLIError('Could not get tenant: ', e.message, asJson)
+                    handleCLIError('Could not get client: ', e.message)
                 }
             },
-            list: async (shortcode, tenantId, asJson) => {
-                let result
+            list: async ({shortcode, tenant}) => {
                 try {
-                    result = await slas.api.client.list(shortcode, tenantId);
-                    if (asJson) {
-                        console.info(JSON.stringify(result, null, 4));
-                    } else {
-                        result.data.forEach((element) => console.table(element));
-                    }
+                    const result = await slas.api.client.list({shortcode, tenant});
+                    console.dir(result, {depth: null});
                 } catch (e) {
-                    handleCLIError('Could not get tenants: ', e.message, asJson)
+                    handleCLIError('Could not list clients: ', e.message)
                 }
             },
             delete: async (tenantId, shortcode, clientId, asJson) => {
@@ -139,29 +149,21 @@ const slas = {
     },
     api: {
         tenant: {
-            add: async ({shortcode, instance, description, merchantName, contact, emailAddress, file}) => {
+            add: async ({shortcode, instance, file}) => {
                 const token = auth.getToken();
-                const userEmail = jsonwebtoken.decode(token).sub
-                
+
                 shortcode = secrets.getScapiShortCode(shortcode);
 
                 let body
                 if (!file) {
                     instance = secrets.getScapiTenantId(instance);
-                    description = description || `Added by SFCC-CI at ${(new Date()).toISOString()}`
-                    contact = contact || auth.getUser() || userEmail
-                    emailAddress = emailAddress || auth.getUser() || userEmail
-
                     body = {
                         instance,
-                        description,
-                        merchantName,
-                        contact,
-                        emailAddress
+                        description: `Added by SFCC-CI at ${(new Date()).toISOString()}`,
+                        emailAddress: jsonwebtoken.decode(token).sub
                     }
                 } else {
                     body = JSON.parse(fs.readFileSync(file, 'utf-8'));
-                    console.log({body})
                     instance = secrets.getScapiTenantId(instance || body.instance);
                 }
 
@@ -178,38 +180,34 @@ const slas = {
                 const response = await fetch(url, options);
                 return await handleResponse(response);
             },
-            get: async (tenantId, shortcode) => {
-                const token = auth.getToken();
-
-                // set fallbacks
-                tenantId = secrets.getScapiTenantId(tenantId);
+            get: async ({shortcode, tenant}) => {
                 shortcode = secrets.getScapiShortCode(shortcode);
+                tenant = secrets.getScapiTenantId(tenant);
 
-                const response = await fetch(getSlasUrl(tenantId, shortcode), {
+                const url = getSlasUrl(tenant, shortcode)
+                const options = {
                     method: 'GET',
                     headers: {
-                        'Authorization': `Bearer ${token}`,
+                        'Authorization': `Bearer ${auth.getToken()}`,
                         'Content-Type': 'application/json'
                     }
-                });
-
+                }
+                const response = await fetch(url, options);
                 return await handleResponse(response);
             },
-            delete: async (tenantId, shortcode) => {
-                const token = auth.getToken();
-
-                // set fallbacks
-                tenantId = secrets.getScapiTenantId(tenantId);
+            delete: async ({shortcode, tenant}) => {
                 shortcode = secrets.getScapiShortCode(shortcode);
+                tenant = secrets.getScapiTenantId(tenant);
 
-                const response = await fetch(getSlasUrl(tenantId, shortcode), {
+                const url = getSlasUrl(tenantId, shortcode);
+                const options = {
                     method: 'DELETE',
                     headers: {
-                        'Authorization': `Bearer ${token}`,
+                        'Authorization': `Bearer ${await auth.getToken()}`,
                         'Content-Type': 'application/json'
                     }
-                });
-
+                }
+                const response = await fetch(url, options);
                 return await handleResponse(response);
             },
         },
@@ -248,37 +246,32 @@ const slas = {
 
                 return await handleResponse(response);
             },
-            get: async (tenantId, shortcode, clientId) => {
-                const token = auth.getToken();
+            get: async ({shortcode, tenant, client}) => {
+                tenant = secrets.getScapiTenantId(tenant);
+                client = secrets.getScapiShortCode(client);
 
-                // set fallbacks
-                tenantId = secrets.getScapiTenantId(tenantId);
-                shortcode = secrets.getScapiShortCode(shortcode);
-
-                const response = await fetch(getSlasUrl(tenantId, shortcode, clientId), {
-                    method: 'GET',
+                const url = getSlasUrl(tenant, shortcode, client);
+                const options = {
                     headers: {
-                        'Authorization': `Bearer ${token}`,
+                        'Authorization': `Bearer ${auth.getToken()}`,
                         'Content-Type': 'application/json'
                     }
-                });
-
+                }
+                const response = await fetch(url, options);
                 return await handleResponse(response);
             },
-            list: async (shortcode, tenantId) => {
-                const token = auth.getToken();
-
-                // set fallbacks
-                tenantId = secrets.getScapiTenantId(tenantId);
+            list: async ({shortcode, tenant}) => {
                 shortcode = secrets.getScapiShortCode(shortcode);
+                tenantId = secrets.getScapiTenantId(tenant);
 
-                const response = await fetch(getSlasUrl(tenantId, shortcode) + '/clients', {
-                    method: 'GET',
+                const url = getSlasUrl(tenant, shortcode) + '/clients'
+                const options = {
                     headers: {
-                        'Authorization': `Bearer ${token}`,
+                        'Authorization': `Bearer ${auth.getToken()}`,
                         'Content-Type': 'application/json'
                     }
-                });
+                }
+                const response = await fetch(url, options);
                 return await handleResponse(response);
             },
             delete: async (tenantId, shortcode, clientId) => {


### PR DESCRIPTION
This is an opinionated fix for https://github.com/SalesforceCommerceCloud/sfcc-ci/issues/265.

1. Removed `slas:tenant:list`. Its backing API requires a staff only / internal role today.
2. Reworked the options for `slas:tenant:add`. Generally I removed options that I felt would be frustrating to set on the command line. Instead, I'd like to encourage folks to use the `--file` based interface. I also tried to code this such that you could provide only a `tenant` and it would work.
3. Removed `slas:tenant:delete`. Its backing API requires a staff only / internal role today.
4. Reworked options for `slas:client:add`. I think setting client options via command line is setting yourself up to fail. Instead, we force folks to pass a `--file`.
5. Removed table display options from `slas:client:(get|list)` – there is no way to display a SLAS client (or clients!) as a table.

---

While making these changes I ran into a # of limitations of Commander@2:

1. No way to set required options.
2. Some options conflict with commander properties (eg. you cannot have a option named `--description`.
3. No way to accept a value of `-` for an option (make a normal pattern of saying `--file -` and accepting STDIN impossible)

Generally where possible, I've tried to follow the existing patterns in the repo.

❤️ ❤️ ❤️ 
