### PR TITLE
fix: --failfast -- TypeError: Cannot read property 'status' of undefined

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -146,7 +146,7 @@ function runSync(instance, job_id, request_doc, asJson, failFast) {
                                 console.info('  No log file available');
                             }
                             // report a failing job gracefully with fail-fast
-                            if (failFast && job_execution.exit_status.status === JOB_EXECUTION_EXIT_STATUS_ERROR ) {
+                            if (failFast && job_execution.exit_status instanceof Object && job_execution.exit_status.status === JOB_EXECUTION_EXIT_STATUS_ERROR ) {
                                 console.error("Job ended with error. You may check the log files for further details.");
                             }
                         }


### PR DESCRIPTION
Depends on https://github.com/SalesforceCommerceCloud/sfcc-ci/pull/8/files
```
Job "sfcc-site-archive-import" started on * * *. Execution id is: 8211* * *
Waiting for job to finish...
Job "sfcc-site-archive-import" finished. Status is: pending (PENDING)

Execution details:

  client_id : ***
  duration : 6667
  execution_status : pending
  id : 8211***
  is_log_file_existing : false
  is_restart : false
  job_id : sfcc-site-archive-import
  log_file_name : Job-sfcc-site-archive-import-***.log
  modification_time : 2022-02-10T20:03:13.703Z
  parameters :
    0 :
      name : ImportMode
      value : merge
    1 :
      name : ImportFile
      value : ***.zip
  start_time : 2022-02-10T20:03:13.703Z
  status : PENDING

Log file:

  No log file available
/opt/hostedtoolcache/node/10.24.1/x64/lib/node_modules/sfcc-ci/lib/job.js:149
                            if (failFast && job_execution.exit_status.status === JOB_EXECUTION_EXIT_STATUS_ERROR ) {
                                                                      ^

TypeError: Cannot read property 'status' of undefined
    at Timeout.<anonymous> (/opt/hostedtoolcache/node/10.24.1/x64/lib/node_modules/sfcc-ci/lib/job.js:149:71)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
```