### PR TITLE
Replacing the hardcoded slashes in the paths with the path.sep property, which allows dynamic paths working on all environments

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -32,10 +32,10 @@ const CARTRIDGE_NAME_REGEX = /cartridges\/([a-z_]+)\/cartridge/;
  * @type {Array}
  */
 const DEFAULT_IGNORE_PATTERNS = [
-    'test/**/*',
-    'coverage/**/*',
-    'documentation/**/*',
-    'docs/**/*',
+    `test${path.sep}**${path.sep}*`,
+    `coverage${path.sep}**${path.sep}*`,
+    `documentation${path.sep}**${path.sep}*`,
+    `docs${path.sep}**${path.sep}*`,
     '*.md'
 ];
 
@@ -360,7 +360,8 @@ function generate(directories, ignorePatterns, targetDirectory, fileName) {
             return acc.concat(ignore.map(ignorePattern => path.join(directory, ignorePattern)));
         }, []);
 
-        const files = await globby(directories.map(directory => path.join(directory, 'cartridges/**/*')), {
+        const files = await globby(directories.map(directory =>
+            path.join(directory, `cartridges${path.sep}**${path.sep}*`)), {
             ignore: ignoreAcrossDirectories
         });
 


### PR DESCRIPTION
Fixes #266 