### PR TITLE
Remove default roles assigned to newly created users, updated command…

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1819,7 +1819,7 @@ program
         console.log('  If an org is passed using -o,--org, the user will be created in the Account Manager');
         console.log('  for the passed org. The login (an email) must be unique. After a successful');
         console.log('  creation the user will receive a confirmation e-mail with a link to activate his');
-        console.log('  account. Default roles of the user in Account Manager are "xchange-user" and "doc-user".');
+        console.log('  account.');
         console.log('');
         console.log('  Use -i,--instance to create a local user is on the Commerce Cloud instance.');
         console.log('  The login must be unique. By default no roles will be assigned to the user on the instance.');
@@ -1829,7 +1829,7 @@ program
         console.log('  Examples:');
         console.log();
         console.log('    $ sfcc-ci user:create --org my-org --login jdoe@email.org --user \'{"firstName":' +
-            '"John", "lastName":"Doe", "roles": ["xchange-user"]}\'');
+            '"John", "lastName":"Doe", "roles": ["controlcenter-user"]}\'');
         console.log('    $ sfcc-ci user:create --instance my-instance --login "my-user" --user \'{"email":' +
             '"jdoe@email.org", "first_name":"John", "last_name":"Doe", "roles": ["Administrator"]}\'');
         console.log();

--- a/lib/user.js
+++ b/lib/user.js
@@ -259,11 +259,6 @@ function createUser(orgID, user, token, callback) {
     // build the request options
     var options = getOptions(API_BASE + '/users', token || auth.getToken(), 'POST');
 
-    // update with default roles
-    if (typeof(user['roles']) === 'undefined') {
-        user['roles'] = [ "xchange-user", "doc-user" ];
-    }
-
     // merge the passed user object with some hard coded properties
     var mergedUser = Object.assign(user, {
         displayName : [ user['firstName'], user['lastName'] ].join(' '),


### PR DESCRIPTION
As of Salesforce Commerce Cloud B2C 22.3 some roles in Account Manager will be deprecated. The deprecation spans roles being created to users who are newly being created by `sfcc-ci user:create` by default, this include role `doc-user` and `xchange-user`. Documentation portal (https://documentation.b2c.commercecloud.salesforce.com) is public since a while and access does not require an authenticated user. The former xChange portal does not exist anymore. We will remove these default roles therefore.