### PR TITLE
#309 adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,52 @@
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide details on how to reproduce your bug. If possible provide as much information in the fields below regarding your environment and versions.
+  - type: input
+    id: version
+    attributes:
+      label: sfcc-ci Version
+      description: Run `sfcc-ci --version`
+      placeholder: x.x.x
+    validations:
+      required: false
+  - type: input
+    id: nodeversion
+    attributes:
+      label: NodeJS Version
+      description: Run `node --version`
+      placeholder: x.x.x
+    validations:
+      required: false
+  - type: input
+    id: path
+    attributes:
+      label: sfcc-ci Path
+      description: Run `which sfcc-ci` on Mac/Linux or `where sfcc-ci` on Windows
+      placeholder: /path/to/sfcc-ci
+    validations:
+      required: false
+  - type: textarea
+    id: hostinfo
+    attributes:
+      label: Host OS Details
+      description: On Mac run `sw_vers` and `uname -a`; on linux `uname -a` and `lsb_release`; Windows `systeminfo` and retrieve the OS Name/Version from the output
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please describe your issue
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant output from the command. If possible use `sfcc-ci -D` for additional debug output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/HELP_WANTED.yml
+++ b/.github/ISSUE_TEMPLATE/HELP_WANTED.yml
@@ -1,0 +1,52 @@
+name: Help Wanted
+description: Request help with using sfcc-ci
+labels: ["help wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide details of your issue. If possible provide as much information in the fields below regarding your environment and versions
+  - type: input
+    id: version
+    attributes:
+      label: sfcc-ci Version
+      description: Run `sfcc-ci --version`
+      placeholder: x.x.x
+    validations:
+      required: false
+  - type: input
+    id: nodeversion
+    attributes:
+      label: NodeJS Version
+      description: Run `node --version`
+      placeholder: x.x.x
+    validations:
+      required: false
+  - type: input
+    id: path
+    attributes:
+      label: sfcc-ci Path
+      description: Run `which sfcc-ci` on Mac/Linux or `where sfcc-ci` on Windows
+      placeholder: /path/to/sfcc-ci
+    validations:
+      required: false
+  - type: textarea
+    id: hostinfo
+    attributes:
+      label: Host OS Details
+      description: On Mac run `sw_vers` and `uname -a`; on linux `uname -a` and `lsb_release`; Windows `systeminfo` and retrieve the OS Name/Version from the output
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant output from the command. If possible use `sfcc-ci -D` for additional debug output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 'Unofficial Commerce Cloud Slack: #sfcc-ci'
+    url: https://sfcc-unofficial.slack.com/archives/CAUFG3SHF
+    about: 'Community help can be found on the CC Unofficial Slack in the #sfcc-ci channel'

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: 'Unofficial Commerce Cloud Slack: #sfcc-ci'
     url: https://sfcc-unofficial.slack.com/archives/CAUFG3SHF
-    about: 'Community help can be found on the CC Unofficial Slack in the #sfcc-ci channel'
+    about: 'Community help can be found on the CC Unofficial Slack (https://github.com/sfcc-unofficial/docs) in the #sfcc-ci channel'

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,3 @@
+Please provide a description of the feature request or steps to reproduce your issue    
+
+For bug reports or help please use the issue templates to provide environment details.

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ coverage
 dist
 node_modules
 .*
+!.github
 *.iml


### PR DESCRIPTION
Many of the help requests/bug reports are environmental in nature. Having a standard set of questions (version, OS, paths, etc) can help us reproduce or debug an issue. Github issue templates makes this easy.

Additionally linking to the unofficial slack can help people who don't know about it.

You can see how this looks here (click `New Issue` or view the test issues): https://github.com/clavery/issue-test/issues 

closes #309 