### PR TITLE
feat(#245): added option for client:auth to force client_credentials grant type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 .*
 *.iml
+dw.json

--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -116,6 +116,14 @@ else
 	exit 1
 fi
 
+echo "Testing command ´sfcc-ci client:auth´ with valid client and user credentials and --client option:"
+node ./cli.js client:auth "$ARG_CLIENT_ID" "$ARG_CLIENT_SECRET" "$ARG_USER" "$ARG_USER_PW" --client
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
 ###############################################################################
 ###### Testing ´sfcc-ci client:auth:token´
 ###############################################################################

--- a/cli.js
+++ b/cli.js
@@ -74,10 +74,15 @@ program
     .option('-a, --authserver [authserver]','The authorization server used to authenticate')
     .option('-r, --renew','Controls whether the authentication should be automatically renewed, ' +
         'once the token expires.')
+    .option('-c, --client', 'Forses authorization with client_credentials type')
     .description('Authenticate an API client with an optional user for automation use')
-    .action(function(client, secret, user, user_password, options) {
-        var renew = ( options.renew ? options.renew : false );
-        require('./lib/auth').auth(client, secret, user, user_password, renew, options.authserver);
+    .action(function(client, secret, user, user_password, cliOptions) {
+        var options = {
+            autoRenew: !!cliOptions.renew,
+            accountManager: cliOptions.authserver,
+            forceClientCredentials: !!cliOptions.client
+        }
+        require('./lib/auth').auth(client, secret, user, user_password, options);
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -100,6 +105,7 @@ program
         console.log('    $ sfcc-ci client:auth my_client_id my_client_secret');
         console.log('    $ sfcc-ci client:auth my_client_id my_client_secret -r');
         console.log('    $ sfcc-ci client:auth my_client_id my_client_secret -a account.demandware.com');
+        console.log('    $ sfcc-ci client:auth my_client_id my_client_secret -c');
         console.log('    $ sfcc-ci client:auth');
         console.log();
     });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -153,12 +153,16 @@ function obtainToken(accountManagerHostOverride, basicAuthUser, basicAuthPasswor
  * @param {String} clientSecret The client secret to use with the authentication flow
  * @param {String} user The user to use with the authentication flow
  * @param {String} userPassword The user password to use with the authentication flow
- * @param {Boolean} autoRenew A flag controlling, wether the access token should be renewed automatically, false by default
- * @param {String} accountManager The optional host name of the Account Manager to use as authorization server
+ * @param {Object} options
+ * @param {Boolean} options.autoRenew A flag controlling, wether the access token should be renewed automatically, false by default
+ * @param {String} options.accountManager The optional host name of the Account Manager to use as authorization server
+ * @param {Boolean} options.forceClientCredentials A flag to force client_credentials grant type
  */
-function auth(client, clientSecret, user, userPassword, autoRenew, accountManager) {
+function auth(client, clientSecret, user, userPassword, options) {
     // determine oauth flow to use, by default it is resource owner password credentials
     var flow = { grant : 'password', response_type : 'code' };
+
+    options = options || {}
 
     // if client and secret are not passed, attempt to look them up from alternative sources, honoring dw.json and env vars
     if ( !client && !clientSecret ) {
@@ -181,13 +185,14 @@ function auth(client, clientSecret, user, userPassword, autoRenew, accountManage
         }
     }
 
-    // if user is unknown, we switch to client_credentials
-    if (!user) {
+    // if user is unknown or flag is provided, we switch to client_credentials
+    if (!user || options.forceClientCredentials) {
         flow = { grant : 'client_credentials', response_type : 'token' };
     }
 
     console.debug('Authorize via Oauth %s grant', flow['grant']);
 
+    var accountManager = options.accountManager
     // default AM host (the production AM)
     var accountManagerHost = getAMHost();
     // alternative AM host
@@ -225,7 +230,7 @@ function auth(client, clientSecret, user, userPassword, autoRenew, accountManage
             setAccessToken(res.body.access_token);
 
             // the auto renew requires to store the base64 encoded client and secret
-            if (autoRenew) {
+            if (options.autoRenew) {
                 var credentials = Buffer.from(client + ':' + clientSecret).toString('base64');
                 // token might null, that's ok
                 setAutoRenewToken(credentials, res.body['refresh_token']);

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -118,7 +118,7 @@ describe('Tests for lib/auth.js', function() {
 
             it('accepts an alternate account manager URI', function() {
                 const accountManager = AMURI1;
-                auth.auth(clientKey, clientSecret, null, null, false, accountManager);
+                auth.auth(clientKey, clientSecret, null, null, { accountManager: accountManager });
                 const postArgs = requestStub.post.getCall(0).args[0];
                 expect(postArgs.uri).to.equal('https://account-pod5.demandware.net/dw/oauth2/access_token');
             });
@@ -141,9 +141,15 @@ describe('Tests for lib/auth.js', function() {
             it('will use accountManager function arg over dwjson config value', function() {
                 const accountManager = AMURI1;
                 dwjsonMock['account-manager'] = AMURI2;
-                auth.auth(clientKey, clientSecret, null, null, false, accountManager);
+                auth.auth(clientKey, clientSecret, null, null, { accountManager: accountManager });
                 const postArgs = requestStub.post.getCall(0).args[0];
                 expect(postArgs.uri).to.equal('https://account-pod5.demandware.net/dw/oauth2/access_token');
+            });
+
+            it('forces client_credentials grant type if flag provided', function() {
+                auth.auth(clientKey, clientSecret, user, password, { forceClientCredentials: true });
+                const postArgs = requestStub.post.getCall(0).args[0];
+                expect(postArgs.form.grant_type).to.equal('client_credentials');
             });
         });
     });


### PR DESCRIPTION
This PR adds backward compatible change for #245.
Note: did not test `client:auth:renew` but looking through the code I suppose it will continue to use `client_credentials` type.