### PR TITLE
Automatically rewrite instance name if certificate is used in code:deploy

### DIFF
--- a/lib/code.js
+++ b/lib/code.js
@@ -166,6 +166,20 @@ function deployCode(instance, archive, token, options, callback) {
         ignoreLocalFilePath = true;
     }
 
+    if(null!=options.pfx && ""!=options.pfx){
+        // assume this is a staging instance because certificate was passed
+        // check if using "incorrect" hostname format
+        var hostnameDomainComponents=instance.split(".");
+        if (3==hostnameDomainComponents.length && hostnameDomainComponents[0].toLowerCase().startsWith("staging-")) {
+            console.debug(`Assuming ${instance} is a staging instance, replacing with cert.* format`);
+            // assume it's staging-* "dashed" hostname format, replace dash with dots
+            hostnameDomainComponents[0]="cert."+hostnameDomainComponents[0].replace(/\-/g, ".");
+            // rebuild the hostname
+            instance=hostnameDomainComponents.join(".");
+            console.debug(`Instance name rewritten to ${instance}`);
+        }
+    }
+    
     // initiate the post request first...
     webdav.postFile(instance, webdav.WEBDAV_CODE, file, token, ignoreLocalFilePath, options, function (err, res, body) {
         ocapi.ensureValidToken(err, res, function(err, res) {

--- a/lib/code.js
+++ b/lib/code.js
@@ -166,11 +166,11 @@ function deployCode(instance, archive, token, options, callback) {
         ignoreLocalFilePath = true;
     }
 
-    if(null!=options.pfx && ""!=options.pfx){
+    if (null!=options.pfx && ""!=options.pfx){
         // assume this is a staging instance because certificate was passed
         // check if using "incorrect" hostname format
         var hostnameDomainComponents=instance.split(".");
-        if (3==hostnameDomainComponents.length && hostnameDomainComponents[0].toLowerCase().startsWith("staging-")) {
+        if (3==hostnameDomainComponents.length && hostnameDomainComponents[0].toLowerCase().startsWith("staging-") && "demandware"==hostnameDomainComponents[1] && "net"==hostnameDomainComponents[2]) {
             console.debug(`Assuming ${instance} is a staging instance, replacing with cert.* format`);
             // assume it's staging-* "dashed" hostname format, replace dash with dots
             hostnameDomainComponents[0]="cert."+hostnameDomainComponents[0].replace(/\-/g, ".");
@@ -179,7 +179,7 @@ function deployCode(instance, archive, token, options, callback) {
             console.debug(`Instance name rewritten to ${instance}`);
         }
     }
-    
+
     // initiate the post request first...
     webdav.postFile(instance, webdav.WEBDAV_CODE, file, token, ignoreLocalFilePath, options, function (err, res, body) {
         ocapi.ensureValidToken(err, res, function(err, res) {

--- a/lib/code.js
+++ b/lib/code.js
@@ -114,7 +114,14 @@ function renderCodeVersions(code_versions) {
             ['ID', 'Activation Time', 'Active', 'Compatibility Mode', 'Last Modification Time', 'Total Size']
         ];
         for (var c of code_versions.data) {
-            data.push([c.id, c.activation_time, c.active, c.compatibility_mode, c.last_modification_time, c.total_size]);
+            data.push([
+                c.id,
+                c.activation_time,
+                c.active,
+                c.compatibility_mode,
+                c.last_modification_time,
+                c.total_size
+            ]);
         }
 
         console.table(data);

--- a/lib/code.js
+++ b/lib/code.js
@@ -15,7 +15,7 @@ var ocapi = require('./ocapi');
 var webdav = require('./webdav');
 
 // enable request debugging
-if ( process.env.DEBUG ) {
+if (process.env.DEBUG) {
     require('request-debug')(request);
 }
 
@@ -34,7 +34,9 @@ function activateVersion(instance, version, token, callback) {
     var options = ocapi.getOptions(instance, endpoint, token, 'PATCH');
 
     // the patch body
-    options['body'] = { active : true };
+    options['body'] = {
+        active: true
+    };
 
     // just do the request and pass the callback
     request(options, callback);
@@ -71,7 +73,7 @@ function getVersions(instance, token, callback) {
 function getSourceCodeVersion(instance, codeVersionName) {
     return new Promise((resolve, reject) => {
         getVersions(instance, auth.getToken(), function (err, res) {
-            ocapi.ensureValidToken(err, res, function(err, res) {
+            ocapi.ensureValidToken(err, res, function (err, res) {
                 if (!err && res.statusCode == 200) {
                     const foundCodeVersion = res.body.data
                         .filter(codeVersion => codeVersion._type === 'code_version')
@@ -83,9 +85,12 @@ function getSourceCodeVersion(instance, codeVersionName) {
                 }
 
                 // in case of errors
-                var result = { error : 'Cannot read code versions', fault : res.body.fault };
+                var result = {
+                    error: 'Cannot read code versions',
+                    fault: res.body.fault
+                };
                 reject(`${result['error']}, ${result['fault']}`);
-            }, function() {
+            }, function () {
                 getSourceCodeVersion(instance, codeVersionName)
                     .then(codeVersion => resolve(codeVersion))
                     .catch(err => reject(err));
@@ -105,9 +110,11 @@ function renderCodeVersions(code_versions) {
 
     // render some details for each
     if (code_versions.total > 0) {
-        var data = [['ID','Activation Time','Active','Compatibility Mode','Last Modification Time','Total Size']];
+        var data = [
+            ['ID', 'Activation Time', 'Active', 'Compatibility Mode', 'Last Modification Time', 'Total Size']
+        ];
         for (var c of code_versions.data) {
-            data.push([c.id,c.activation_time,c.active,c.compatibility_mode,c.last_modification_time,c.total_size]);
+            data.push([c.id, c.activation_time, c.active, c.compatibility_mode, c.last_modification_time, c.total_size]);
         }
 
         console.table(data);
@@ -125,19 +132,19 @@ function renderCodeVersions(code_versions) {
  */
 function deployCode(instance, archive, token, options, callback) {
     // check parameters
-    if (typeof(instance) !== 'string') {
+    if (typeof (instance) !== 'string') {
         throw new TypeError('Parameter instance is missing or not of type String');
     }
-    if (typeof(archive) !== 'string') {
+    if (typeof (archive) !== 'string') {
         throw new TypeError('Parameter archive is missing or not of type String');
     }
-    if (typeof(token) !== 'string') {
+    if (typeof (token) !== 'string') {
         throw new TypeError('Parameter token is missing or not of type String');
     }
-    if (typeof(options) !== 'object') {
+    if (typeof (options) !== 'object') {
         options = {};
     }
-    if (typeof(callback) !== 'function') {
+    if (typeof (callback) !== 'function') {
         throw new TypeError('Parameter callback is missing or not of type Function');
     }
 
@@ -166,27 +173,29 @@ function deployCode(instance, archive, token, options, callback) {
         ignoreLocalFilePath = true;
     }
 
-    if (null!=options.pfx && ""!=options.pfx){
+    if (null != options.pfx && "" != options.pfx) {
         // assume this is a staging instance because certificate was passed
         // check if using "incorrect" hostname format
-        var hostnameDomainComponents=instance.split(".");
-        if (3==hostnameDomainComponents.length && hostnameDomainComponents[0].toLowerCase().startsWith("staging-") && "demandware"==hostnameDomainComponents[1] && "net"==hostnameDomainComponents[2]) {
+        var domain = instance.split(".");
+        if (3 == domain.length &&
+            domain[0].toLowerCase().startsWith("staging-") &&
+            instance.toLowerCase().endsWith(".demandware.net")) {
             console.debug(`Assuming ${instance} is a staging instance, replacing with cert.* format`);
             // assume it's staging-* "dashed" hostname format, replace dash with dots
-            hostnameDomainComponents[0]="cert."+hostnameDomainComponents[0].replace(/\-/g, ".");
+            domain[0] = "cert." + domain[0].replace(/\-/g, ".");
             // rebuild the hostname
-            instance=hostnameDomainComponents.join(".");
+            instance = domain.join(".");
             console.debug(`Instance name rewritten to ${instance}`);
         }
     }
 
     // initiate the post request first...
     webdav.postFile(instance, webdav.WEBDAV_CODE, file, token, ignoreLocalFilePath, options, function (err, res, body) {
-        ocapi.ensureValidToken(err, res, function(err, res) {
+        ocapi.ensureValidToken(err, res, function (err, res) {
             // note, server respond with a 401 (Authorization required) in case the WebDAV Client permission is not set
             if (res && res.statusCode >= 400) {
-                callback(new Error(`Deploy code ${file} failed (upload step): `
-                    + `${res.statusCode} (${res.statusMessage})`));
+                callback(new Error(`Deploy code ${file} failed (upload step): ` +
+                    `${res.statusCode} (${res.statusMessage})`));
                 return;
             } else if (err) {
                 callback(new Error(`Deploy code ${file} failed (upload step): ${err}`));
@@ -197,8 +206,8 @@ function deployCode(instance, archive, token, options, callback) {
                 function (err, res, body) {
                     // note, server respond with a 401 (Authorization required) in case the WebDAV Client permission is not set
                     if (res && res.statusCode >= 400) {
-                        callback(new Error(`Deploy code ${file} failed (unzip step): `
-                            + `${res.statusCode} (${res.statusMessage})`));
+                        callback(new Error(`Deploy code ${file} failed (unzip step): ` +
+                            `${res.statusCode} (${res.statusMessage})`));
                         return;
                     } else if (err) {
                         callback(new Error(`Deploy code ${file} failed (unzip step): ${err}`));
@@ -213,10 +222,10 @@ function deployCode(instance, archive, token, options, callback) {
 
                     // If the code is successfully deployed, we need to remove the uploaded ZIP file
                     webdav.deleteFile(instance, webdav.WEBDAV_CODE, file, token, ignoreLocalFilePath, options,
-                        function(err, res, body) {
+                        function (err, res, body) {
                             if (err) {
-                                callback(new Error(`Delete ZIP file ${file} after deployment `
-                                    + `failed (deleteFile step): ${err}`));
+                                callback(new Error(`Delete ZIP file ${file} after deployment ` +
+                                    `failed (deleteFile step): ${err}`));
                                 return;
                             } else {
                                 if (res && res.statusCode === 204) {
@@ -229,7 +238,7 @@ function deployCode(instance, archive, token, options, callback) {
                             }
                         });
                 });
-        }, function() {
+        }, function () {
             deployCode(instance, archive, token, options, callback);
         });
     });
@@ -263,7 +272,7 @@ function postFileToInstance(instance, codeVersionName, filePath, options) {
             true,
             options,
             (err, res) => {
-                ocapi.ensureValidToken(err, res, function(err, res) {
+                ocapi.ensureValidToken(err, res, function (err, res) {
                     // note, server respond with a 401 (Authorization required) in case the WebDAV Client permission is not set
                     if (res && res.statusCode >= 400) {
                         reject(`Post file "${filePath}" failed: ${res.statusCode} (${res.statusMessage})`);
@@ -274,7 +283,7 @@ function postFileToInstance(instance, codeVersionName, filePath, options) {
                     }
 
                     resolve(res);
-                }, function() {
+                }, function () {
                     postFileFromInstance(instance, codeVersionName, filePath, options)
                         .then(res => resolve(res))
                         .catch(err => reject(err));
@@ -312,7 +321,7 @@ function removeFileFromInstance(instance, codeVersionName, filePath, options) {
             true,
             options,
             (err, res) => {
-                ocapi.ensureValidToken(err, res, function(err, res) {
+                ocapi.ensureValidToken(err, res, function (err, res) {
                     // note, server respond with a 401 (Authorization required) in case the WebDAV Client permission is not set
                     if (res && res.statusCode >= 400) {
                         reject(`Remove file "${filePath}" failed: ${res.statusCode} (${res.statusMessage})`);
@@ -323,7 +332,7 @@ function removeFileFromInstance(instance, codeVersionName, filePath, options) {
                     }
 
                     resolve(res);
-                }, function() {
+                }, function () {
                     removeFileFromInstance(instance, codeVersionName, filePath, options)
                         .then(res => resolve(res))
                         .catch(err => reject(err));
@@ -350,10 +359,10 @@ function deleteCodeVersion(instance, version, callback) {
     // do the request
     request(options, function (err, res, body) {
         var errback = ocapi.captureCommonErrors(err, res);
-        if ( errback ) {
+        if (errback) {
             callback(errback, []);
             return;
-        } else if ( err ) {
+        } else if (err) {
             callback(new Error(`Deleting code version ${version} failed: ${err}`));
             return;
         } else if (res.statusCode >= 400) {
@@ -373,9 +382,9 @@ module.exports.cli = {
      * @param {Boolean} asJson whether to format the output as json, default is false
      * @param {String} sortBy the field to sort code versions by
      */
-    list : function (instance, asJson, sortBy) {
+    list: function (instance, asJson, sortBy) {
         getVersions(instance, auth.getToken(), function (err, res) {
-            ocapi.ensureValidToken(err, res, function(err, res) {
+            ocapi.ensureValidToken(err, res, function (err, res) {
                 if (!err && res.statusCode == 200) {
                     // apply sorting
                     if (sortBy) {
@@ -389,7 +398,10 @@ module.exports.cli = {
                     return;
                 }
                 // in case of errors
-                var result = { error : 'Cannot read code versions', fault : res.body.fault };
+                var result = {
+                    error: 'Cannot read code versions',
+                    fault: res.body.fault
+                };
 
                 if (asJson) {
                     console.json(result);
@@ -397,7 +409,7 @@ module.exports.cli = {
                 }
                 console.error(result['error']);
                 console.debug(result['fault']);
-            }, function() {
+            }, function () {
                 list(instance, asJson, sortby);
             });
         });
@@ -411,8 +423,8 @@ module.exports.cli = {
      * @param {Object} options The options parameter can contains client certificate buffer and related passphrase in case of two factor authentication
      * @param {Boolean} activate Whether to activate the uploaded code version or not, false by default
      */
-    deploy : function (instance, archive, options, activate) {
-        deployCode(instance, archive, auth.getToken(), options, function(err, newVersion) {
+    deploy: function (instance, archive, options, activate) {
+        deployCode(instance, archive, auth.getToken(), options, function (err, newVersion) {
             if (err) {
                 console.error(err.message);
             } else if (!activate) {
@@ -439,7 +451,7 @@ module.exports.cli = {
      * @param {String} instance The instance to activate the code on
      * @param {String} code_version The code version to activate
      */
-    activate : function (instance, code_version) {
+    activate: function (instance, code_version) {
         return new Promise((resolve, reject) => {
             activateVersion(instance, code_version, auth.getToken(), (e, r) => {
                 ocapi.ensureValidToken(e, r, (err, res) => {
@@ -474,11 +486,13 @@ module.exports.cli = {
      * @param {String} version the code version to delete
      * @param {Boolean} asJson optional flag to force output in json, false by default
      */
-    delete : function(instance, version, asJson) {
-        deleteCodeVersion(instance, version, function(err) {
+    delete: function (instance, version, asJson) {
+        deleteCodeVersion(instance, version, function (err) {
             if (err) {
                 if (asJson) {
-                    console.json({error: err.message});
+                    console.json({
+                        error: err.message
+                    });
                 } else {
                     console.error(err.message);
                 }
@@ -487,7 +501,7 @@ module.exports.cli = {
 
             // the result
             var result = {
-                message : `Code version ${version} deleted from ${instance}.`,
+                message: `Code version ${version} deleted from ${instance}.`,
             };
 
             if (asJson) {
@@ -519,13 +533,13 @@ module.exports.cli = {
      * @resolve {String} The full path of the newly created results output file or undefined if the option outputFile is not passed
      * @reject {String} An error message if the process failed
      */
-    compare : function (instance, localDirectories, options) {
+    compare: function (instance, localDirectories, options) {
         return new Promise(async (resolve, reject) => {
             try {
                 options.verbose && console.log(`Starting the compare process between the "${localDirectories}" local ` +
                     `directories and the active code version of "${instance}".`);
 
-                if (typeof(localDirectories) === 'string') {
+                if (typeof (localDirectories) === 'string') {
                     localDirectories = localDirectories.split(',');
                 }
 
@@ -569,7 +583,7 @@ module.exports.cli = {
                 // #3
                 options.verbose && console.log('Generating the local manifest based on the given local directories.');
                 let ignorePatterns = options.ignorePatterns;
-                if (options.ignorePatterns && typeof(options.ignorePatterns) === 'string') {
+                if (options.ignorePatterns && typeof (options.ignorePatterns) === 'string') {
                     ignorePatterns = options.ignorePatterns.split(',');
                 }
                 const localManifestPath = await manifest.generate(
@@ -636,13 +650,13 @@ module.exports.cli = {
      * @resolve {undefined} undefined, meaning that everything worked well
      * @reject {String} An error message if the process failed
      */
-    diffdeploy : function (instance, localDirectories, codeVersionName, options, activate) {
+    diffdeploy: function (instance, localDirectories, codeVersionName, options, activate) {
         return new Promise(async (resolve, reject) => {
             try {
                 options.verbose && console.log(`Starting the diff-deployment process between ` +
                     `the "${localDirectories}" local directories and the active code version of "${instance}".`);
 
-                if (typeof(localDirectories) === 'string') {
+                if (typeof (localDirectories) === 'string') {
                     localDirectories = localDirectories.split(',');
                 }
 
@@ -686,7 +700,7 @@ module.exports.cli = {
                 // #3
                 options.verbose && console.log('Generating the local manifest based on the given local directories.');
                 let ignorePatterns = options.ignorePatterns;
-                if (options.ignorePatterns && typeof(options.ignorePatterns) === 'string') {
+                if (options.ignorePatterns && typeof (options.ignorePatterns) === 'string') {
                     ignorePatterns = options.ignorePatterns.split(',');
                 }
                 const localManifestPath = await manifest.generate(
@@ -702,7 +716,7 @@ module.exports.cli = {
                 options.verbose && console.log(`Comparing the local manifest "${localManifestPath}" ` +
                     `with the previously downloaded remote one "${downloadManifestTargetPath}".`);
                 let forceDeployPatterns = options.forceDeployPatterns;
-                if (options.forceDeployPatterns && typeof(options.forceDeployPatterns) === 'string') {
+                if (options.forceDeployPatterns && typeof (options.forceDeployPatterns) === 'string') {
                     forceDeployPatterns = options.forceDeployPatterns.split(',');
                 }
                 const delta = await manifest.compareAndAggregateResults(
@@ -821,19 +835,19 @@ module.exports.api = {
      * @param {String} token The Oauth token to use for authentication
      * @param {Function} callback Callback function executed as a result. The error and the code versions will be passed as parameters to the callback function.
      */
-    list : function (instance, token, callback) {
+    list: function (instance, token, callback) {
         // check parameters
-        if (typeof(instance) !== 'string') {
+        if (typeof (instance) !== 'string') {
             throw new TypeError('Parameter instance is missing or not of type String');
         }
-        if (typeof(token) !== 'string') {
+        if (typeof (token) !== 'string') {
             throw new TypeError('Parameter token is missing or not of type String');
         }
-        if (typeof(callback) !== 'function') {
+        if (typeof (callback) !== 'function') {
             throw new TypeError('Parameter callback is missing or not of type Function');
         }
         getVersions(instance, token, function (err, res) {
-            ocapi.ensureValidToken(err, res, function(err, res) {
+            ocapi.ensureValidToken(err, res, function (err, res) {
                 if (!err && res.statusCode == 200 && !res.fault) {
                     // Success
                     callback(undefined, res.body);
@@ -869,22 +883,22 @@ module.exports.api = {
      * @param {String} token The Oauth token to use for authentication
      * @param {Function} callback Callback function executed as a result. The error will be passed as parameter to the callback function.
      */
-    activate : function (instance, code_version, token, callback) {
+    activate: function (instance, code_version, token, callback) {
         // check parameters
-        if (typeof(instance) !== 'string') {
+        if (typeof (instance) !== 'string') {
             throw new TypeError('Parameter instance is missing or not of type String');
         }
-        if (typeof(code_version) !== 'string') {
+        if (typeof (code_version) !== 'string') {
             throw new TypeError('Parameter code_version is missing or not of type String');
         }
-        if (typeof(token) !== 'string') {
+        if (typeof (token) !== 'string') {
             throw new TypeError('Parameter token is missing or not of type String');
         }
-        if (typeof(callback) !== 'function') {
+        if (typeof (callback) !== 'function') {
             throw new TypeError('Parameter callback is missing or not of type Function');
         }
         activateVersion(instance, code_version, token, function (err, res) {
-            ocapi.ensureValidToken(err, res, function(err, res) {
+            ocapi.ensureValidToken(err, res, function (err, res) {
                 if (!err && res.statusCode == 200 && !res.fault) {
                     // Success
                     callback(undefined);
@@ -949,5 +963,5 @@ module.exports.api = {
      * @resolve {undefined} undefined, meaning that everything worked well
      * @reject {String} An error message if the process failed
      */
-    diffdeploy : module.exports.cli.diffdeploy
+    diffdeploy: module.exports.cli.diffdeploy
 };


### PR DESCRIPTION
Certificate is used to replace 2FA in STG, therefore if certificate is used, target is a STG instance; if the format is `staging-this-that-whatever.demandware.net`, rewrite the hostname to `cert.staging.this.that.whatever.demandware.net`