### PR TITLE
Add support for Sandbox API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Use `sfcc-ci --help` or just `sfcc-ci` to get started and see the full list of c
     $SFCC_OAUTH_CLIENT_SECRET          client secret used for authentication
     $SFCC_OAUTH_USER_NAME              user name used for authentication
     $SFCC_OAUTH_USER_PASSWORD          user password used for authentication
-    $SFCC_SANDBOX_API_HOST             set sandbox API host
+    $SFCC_SANDBOX_API_HOST             set alternative sandbox API host
     $SFCC_SANDBOX_API_POLLING_TIMEOUT  set timeout for sandbox polling in minutes
     $SFCC_SCAPI_SHORTCODE              the Salesforce Commerce (Headless) API Shortcode
     $SFCC_SCAPI_TENANTID               the Salesforce Commerce (Headless) API TenantId
@@ -399,7 +399,7 @@ The use of environment variables is optional. `sfcc-ci` respects the following e
 * `SFCC_OAUTH_CLIENT_SECRET` client secret used for authentication
 * `SFCC_OAUTH_USER_NAME` user name used for authentication
 * `SFCC_OAUTH_USER_PASSWORD` user password used for authentication
-* `SFCC_SANDBOX_API_HOST` set sandbox API host
+* `SFCC_SANDBOX_API_HOST` set alternative sandbox API host
 * `SFCC_SANDBOX_API_POLLING_TIMEOUT` set timeout for sandbox polling in minutes
 * `DEBUG` enable verbose output
 
@@ -478,7 +478,7 @@ users:* | Account Administrator role assigned to user _or_ OCAPI Data API Settin
 
 ### API Server ###
 
-`sfcc-ci` uses a default host for the sandbox API. You can overwrite this host and use an alternative host using the env var `SFCC_SANDBOX_API_HOST`:
+`sfcc-ci` uses a default host for the sandbox API. This is the standard Sandbox API Gateway at admin.dx.commercecloud.salesforce.com. Usually this is fine and you don't need to change this. However, you can overwrite this host and use an alternative host using the env var `SFCC_SANDBOX_API_HOST`:
 
 ```bash
 export SFCC_SANDBOX_API_HOST=<alternative-sandbox-api-host>

--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -320,6 +320,37 @@ else
 fi
 
 ###############################################################################
+###### Testing ´sfcc-ci sandbox:ips´
+###############################################################################
+
+echo "Testing command ´sfcc-ci sandbox:ips´:"
+node ./cli.js sandbox:ips
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
+echo "Testing command ´sfcc-ci sandbox:ips --realm (expected to fail)´:"
+node ./cli.js sandbox:ips --realm
+if [ $? -eq 1 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
+echo "Testing command ´sfcc-ci sandbox:ips --realm <realm>´:"
+node ./cli.js sandbox:ips --realm $ARG_SANDBOX_REALM
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
+###############################################################################
 ###### Testing ´sfcc-ci sandbox:list´
 ###############################################################################
 

--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -1201,7 +1201,7 @@ else
 fi
 
 echo "Testing command ´sfcc-ci user:create --login <login>´:"
-node ./cli.js user:create --login "$ARG_TEST_USER" --user '{"firstName": "John", "lastName": "Doe"}'
+node ./cli.js user:create --org "$ARG_TEST_ORG" --login "$ARG_TEST_USER" --user '{"firstName": "John", "lastName": "Doe"}'
 if [ $? -eq 0 ]; then
     echo -e "\t> OK"
 else
@@ -1253,8 +1253,8 @@ else
 	exit 1
 fi
 
-echo "Testing command ´sfcc-ci user:delete --login <login>´ with invalid user (expected to fail):"
-node ./cli.js user:delete --login does_not_exist
+echo "Testing command ´sfcc-ci user:delete --login <login>´ --noprompt with invalid user (expected to fail):"
+node ./cli.js user:delete --login does_not_exist --noprompt
 if [ $? -eq 1 ]; then
     echo -e "\t> OK"
 else

--- a/cli.js
+++ b/cli.js
@@ -268,15 +268,23 @@ program
 program
     .command('sandbox:ips')
     .description('List inbound and outbound IP addresses for sandboxes')
+    .option('-r, --realm <realm>','Realm to get IP details for')
     .option('-j, --json','Formats the output in json')
     .action(function(options) {
+        var realm = ( options.realm ? options.realm : null );
         var asJson = ( options.json ? options.json : false );
-        require('./lib/sandbox').cli.ips(asJson);
+        require('./lib/sandbox').cli.ips(realm, asJson);
     }).on('--help', function() {
+        console.log('');
+        console.log('  Details:');
+        console.log();
+        console.log('  Use the optional --realm parameter to only retrieve IP addresses relevant for a particular');
+        console.log('  realm.');
         console.log('');
         console.log('  Examples:');
         console.log();
         console.log('    $ sfcc-ci sandbox:ips');
+        console.log('    $ sfcc-ci sandbox:ips --realm zzzz');
         console.log('    $ sfcc-ci sandbox:ips --json');
         console.log();
     });
@@ -2135,7 +2143,7 @@ program.on('--help', function() {
     console.log('    $SFCC_OAUTH_CLIENT_SECRET          client secret used for authentication');
     console.log('    $SFCC_OAUTH_USER_NAME              user name used for authentication');
     console.log('    $SFCC_OAUTH_USER_PASSWORD          user password used for authentication');
-    console.log('    $SFCC_SANDBOX_API_HOST             set sandbox API host');
+    console.log('    $SFCC_SANDBOX_API_HOST             set alternative sandbox API host');
     console.log('    $SFCC_SANDBOX_API_POLLING_TIMEOUT  set timeout for sandbox polling in minutes')
     console.log('    $SFCC_SCAPI_SHORTCODE              the Salesforce Commerce (Headless) API Shortcode');
     console.log('    $SFCC_SCAPI_TENANTID               the Salesforce Commerce (Headless) API TenantId')

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -17,7 +17,7 @@ var dwjson = require('./dwjson').init();
 var ocapi = require('./ocapi');
 var readline = require('readline');
 
-const API_HOST_DEFAULT = 'admin.us01.dx.commercecloud.salesforce.com';
+const API_HOST_DEFAULT = 'admin.dx.commercecloud.salesforce.com';
 const API_HOST = getAPIHost();
 const API_BASE = API_HOST + '/api/v1';
 const API_SANDBOXES = API_BASE + '/sandboxes';
@@ -235,8 +235,12 @@ function askQuestion(query) {
 /**
  * Prints the inbound IP addresses of the cluster on the console.
  */
-function printInboundIPs(json, cli) {
-    var options = ocapi.getOptions('GET', API_SYSTEM);
+function printInboundIPs(realm, json, cli) {
+    var endpoint = API_SYSTEM;
+    if (realm !== null) {
+        endpoint = API_BASE + `/realms/${realm}/system`;
+    }
+    var options = ocapi.getOptions('GET', endpoint);
 
     ocapi.retryableCall('GET', options, function (err, res) {
         if (err) {
@@ -253,7 +257,7 @@ function printInboundIPs(json, cli) {
                 return;
             }
             console.log('');
-            console.log('Inbound IP addresses:');
+            console.log('Inbound IP addresses' + ( realm !== null ? ` (for realm ${realm})` : '' ) + ':');
 
             // table fields
             var data = [['address']];
@@ -268,8 +272,12 @@ function printInboundIPs(json, cli) {
 /**
  * Prints the outbound IP addresses of the cluster on the console.
  */
-function printOutboundIPs(json, cli) {
-    var options = ocapi.getOptions('GET', API_SYSTEM);
+function printOutboundIPs(realm, json, cli) {
+    var endpoint = API_SYSTEM;
+    if (realm !== null) {
+        endpoint = API_BASE + `/realms/${realm}/system`;
+    }
+    var options = ocapi.getOptions('GET', endpoint);
 
     ocapi.retryableCall('GET', options, function (err, res) {
         if (err) {
@@ -286,7 +294,7 @@ function printOutboundIPs(json, cli) {
                 return;
             }
             console.log('');
-            console.log('Outbound IP addresses:');
+            console.log('Outbound IP addresses' + ( realm !== null ? ` (for realm ${realm})` : '' ) + ':');
 
             // table fields
             var data = [['address']];
@@ -713,15 +721,16 @@ function triggerOperation(id, operation, callback) {
 /**
  * Calls the given alias registration link in the browser after printing the inbound cluster IPs.
  *
+ * @param {String} realm realm to lookup ips for
  * @param {String} link registration link
  * @param {String} host host name
  */
-function doCookieRegistration(link, host) {
+function doCookieRegistration(realm, link, host) {
     if (!link) {
         console.warn("No registration link provided.");
         return
     }
-    printInboundIPs();
+    printInboundIPs(realm);
     (async() => {
         await askQuestion('Please point the domain (' + host + ') in your etc/hosts to one of the inbound IP ' +
             'addresses and set the alias in your instance\'s site alias configuration (in Business Manager at: ' +
@@ -820,20 +829,16 @@ function unregisterForSandbox(sbxID, aliasID, callback) {
 /**
  * Runs a callback function for a sandbox, which is defined by a specification object. This specification has to
  * either contain the sandbox UUID as field 'id' or it's 'realm' and 'instance'. The callback function then gets
- * the sandbox UUID as a parameter.
+ * the sandbox as a parameter.
  * NOTE that the callback function is NOT called, if there was no sandbox found.
  *
  * @param spec      specification object with sandbox ID or tenant information
  * @param asJson    true, for json logging enabled
- * @param callback  callback function which gets the sandbox ID as parameter
+ * @param callback  callback function which gets the sandbox as parameter
  */
 function runForSandbox(spec, asJson, callback) {
     if ( !( spec['id'] || ( spec['realm'] && spec['instance'] ) ) ) {
         console.error('Provide either an id or a realm and an instance of the sandbox.');
-        return;
-    }
-    if (spec['id']) {
-        callback(spec['id']);
         return;
     }
     lookupSandbox(spec, function(err, foundSandbox) {
@@ -845,7 +850,7 @@ function runForSandbox(spec, asJson, callback) {
             }
             return;
         }
-        callback(foundSandbox.id);
+        callback(foundSandbox);
     });
 }
 
@@ -992,9 +997,9 @@ module.exports.cli = {
         });
     },
 
-    ips : function (asJson) {
+    ips : function (realm, asJson) {
 
-        printInboundIPs(asJson, true, function(err, ips) {
+        printInboundIPs(realm, asJson, true, function(err, ips) {
             if (err) {
                 console.error(err.message);
                 return;
@@ -1005,14 +1010,14 @@ module.exports.cli = {
             }
 
             if (ips.length === 0) {
-                console.info('No sandboxes found');
+                console.info('No details found');
                 return;
             }
 
             console.info(ips);
         });
 
-        printOutboundIPs(asJson, true, function(err, ips) {
+        printOutboundIPs(realm, asJson, true, function(err, ips) {
             if (err) {
                 console.error(err.message);
                 return;
@@ -1023,7 +1028,7 @@ module.exports.cli = {
             }
 
             if (ips.length === 0) {
-                console.info('No sandboxes found');
+                console.info('No details found');
                 return;
             }
 
@@ -1614,7 +1619,7 @@ module.exports.cli = {
          */
         create : function (spec, alias, unique, asJson) {
             runForSandbox(spec, asJson, function (sandbox) {
-                registerForSandbox(sandbox, alias, unique, function (err, result) {
+                registerForSandbox(sandbox.id, alias, unique, function (err, result) {
                     if (err) {
                         if (asJson) {
                             console.json({error: err.message});
@@ -1638,7 +1643,7 @@ module.exports.cli = {
                         // open registration link automatically if in interactive mode
                         // assuming this is the case when --json flag is not used
                         console.prettyPrint(result);
-                        doCookieRegistration(result.registration, alias);
+                        doCookieRegistration(sandbox.realm, result.registration, alias);
                     }
                 });
             });
@@ -1653,7 +1658,7 @@ module.exports.cli = {
          */
         get : function (spec, alias, asJson) {
             runForSandbox(spec, asJson, function (sandbox) {
-                readAliasConfig(sandbox, alias, function (err, result) {
+                readAliasConfig(sandbox.id, alias, function (err, result) {
                     if (err) {
                         if (asJson) {
                             console.json({error: err.message});
@@ -1668,7 +1673,7 @@ module.exports.cli = {
                         // open registration link automatically if in interactive mode
                         // assuming this is the case when --json flag is not used
                         console.prettyPrint(result);
-                        doCookieRegistration(result.registration, alias);
+                        doCookieRegistration(sandbox.realm, result.registration, alias);
                     }
                 });
             });
@@ -1682,7 +1687,7 @@ module.exports.cli = {
          */
         list : function (spec, asJson) {
             runForSandbox(spec, asJson, function (sandbox) {
-                listForSandbox(sandbox, function (err, list) {
+                listForSandbox(sandbox.id, function (err, list) {
                     if (err) {
                         if (asJson) {
                             console.json({error: err.message});
@@ -1691,7 +1696,7 @@ module.exports.cli = {
                         }
                         return;
                     }
-                    printInboundIPs(asJson);
+                    printInboundIPs(sandbox.realm, asJson);
                     if (asJson) {
                         console.json(list);
                         return;
@@ -1719,8 +1724,8 @@ module.exports.cli = {
          * @param {Boolean} asJson optional flag to force output in json, false by default
          */
         delete : function (spec, aliasId, asJson) {
-            runForSandbox(spec, asJson, function (sbxId) {
-                unregisterForSandbox(sbxId, aliasId, function (err) {
+            runForSandbox(spec, asJson, function (sandbox) {
+                unregisterForSandbox(sandbox.id, aliasId, function (err) {
                     if (err) {
                         if (asJson) {
                             console.json({error: err.message});

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -489,8 +489,8 @@ function lookupSandbox(spec, callback) {
             callback(err);
             return;
         }
-        if ( list.length === 0 ) {
-            callback(undefined, null);
+        if ( typeof(list) === 'undefined' || list.length === 0 ) {
+            callback(new Error('Cannot lookup sandbox.'), null);
             return;
         }
         var filtered = list.filter(function(cand) {
@@ -971,17 +971,21 @@ module.exports.cli = {
                 return;
             }
 
+            if (typeof(list) === 'undefined' || list.length === 0) {
+                if (asJson) {
+                    console.json([]);
+                } else {
+                    console.info('No sandboxes found');
+                }
+                return;
+            }
+
             if (sortBy) {
                 list = require('./json').sort(list, sortBy);
             }
 
             if (asJson) {
                 console.json(list);
-                return;
-            }
-
-            if (list.length === 0) {
-                console.info('No sandboxes found');
                 return;
             }
 
@@ -1610,7 +1614,7 @@ module.exports.cli = {
 
     alias : {
         /**
-         * Registers an alias for a sandbox  and forces a registration.
+         * Registers an alias for a sandbox and forces a registration.
          *
          * @param {String} spec the sandbox id or tenant
          * @param {String} alias the alias name to register for the sandbox
@@ -1652,7 +1656,7 @@ module.exports.cli = {
         /**
          * Reads a specific alias for a sandbox and forces a registration.
          *
-         * @param {String} spec the sandbox id ot tenant
+         * @param {String} spec the sandbox id or tenant
          * @param {String} alias ID of the alias to read for the sandbox
          * @param {Boolean} asJson optional flag to force output in json, false by default
          */

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -452,8 +452,7 @@ function updateRealm(realmID, maxSandboxTTL, defaultSandboxTTL, callback) {
  * @param {Function} callback the callback to execute, the error and the list of sandboxes are available as arguments to the callback function
  */
 function getAllSandboxes(includeDeleted, callback) {
-    ocapi.retryableCall('GET', API_SANDBOXES + '?include_deleted=' +
-        ( includeDeleted ? 'true' : 'false' ), function(err, res) {
+    ocapi.retryableCall('GET', API_SANDBOXES + ( includeDeleted ? '?include_deleted=true' : '' ), function(err, res) {
         var list = [];
         if ( err ) {
             callback(new Error(util.format('Retrieving list of sandboxes failed: %s', err)), []);
@@ -500,14 +499,14 @@ function lookupSandbox(spec, callback) {
         });
 
         if ( filtered.length === 0 ) {
-            callback(undefined, null);
+            callback(new Error('Cannot find sandbox with given ID.'), null);
             return;
         } else if ( filtered.length === 1 ) {
             callback(undefined, filtered[0]);
             return;
         }
 
-        callback(new Error('Found ' + filtered.length + ' matching sandboxes'));
+        callback(new Error('Found ' + filtered.length + ' matching sandboxes.'));
     });
 }
 

--- a/test/unit/sandbox.js
+++ b/test/unit/sandbox.js
@@ -50,6 +50,18 @@ describe('Alias Tests for lib/sandbox.js', function() {
             domainVerificationRecord: "verify=yes"
         }]
     };
+    const sandboxList = {
+        kind: "SandboxList",
+        code: 200,
+        status: "Success",
+        data: [{
+            id: "s1",
+            realm: "zzzz",
+        },{
+            id: "s2",
+            realm: "zzzz"
+        }]
+    };
     var sandbox = proxyquire('../../lib/sandbox', {
         'request': requestStub,
         './auth': {
@@ -92,7 +104,9 @@ describe('Alias Tests for lib/sandbox.js', function() {
                     }
                     return
                 }
-                if (method === 'GET') {
+                if (method === 'GET' && url.endsWith('/sandboxes')) {
+                    responseHandler("", {statusCode: 200, body: sandboxList})
+                } else if (method === 'GET') {
                     responseHandler("", {statusCode: 200, body: existingAlias})
                 } else {
                     // delete
@@ -122,16 +136,16 @@ describe('Alias Tests for lib/sandbox.js', function() {
             sinon.assert.calledWith(consError, "Reading sandbox alias failed: Alias not found.");
         });
         it('Read SBX alias, invalid sandbox', () => {
-            sandbox.cli.alias.get({id: "invalidSandboxId"},"s1", true);
-            sinon.assert.calledWith(consJson, {error: "Reading sandbox alias failed: Invalid sandbox ID."});
-            sandbox.cli.alias.get({id: "invalidSandboxId"},"s1", false);
-            sinon.assert.calledWith(consError, "Reading sandbox alias failed: Invalid sandbox ID.");
+            sandbox.cli.alias.get({id: "invalidSandboxId"},"a1", true);
+            sinon.assert.calledWith(consJson, {error: "Cannot find sandbox with given ID."});
+            sandbox.cli.alias.get({id: "invalidSandboxId"},"a1", false);
+            sinon.assert.calledWith(consError, "Cannot find sandbox with given ID.");
         });
         it('Read SBX alias, sandbox not found', () => {
-            sandbox.cli.alias.get({id: "unknownSandboxId"},"s1", true);
-            sinon.assert.calledWith(consJson, {error: "Reading sandbox alias failed: Sandbox not found."});
-            sandbox.cli.alias.get({id: "unknownSandboxId"},"s1", false);
-            sinon.assert.calledWith(consError, "Reading sandbox alias failed: Sandbox not found.");
+            sandbox.cli.alias.get({id: "unknownSandboxId"},"a1", true);
+            sinon.assert.calledWith(consJson, {error: "Cannot find sandbox with given ID."});
+            sandbox.cli.alias.get({id: "unknownSandboxId"},"a1", false);
+            sinon.assert.calledWith(consError, "Cannot find sandbox with given ID.");
         });
     })
 
@@ -144,15 +158,15 @@ describe('Alias Tests for lib/sandbox.js', function() {
         });
         it('Create SBX alias, invalid sandbox', () => {
             sandbox.cli.alias.create({id: "invalidSandboxId"},"alias", false, true);
-            sinon.assert.calledWith(consJson, {error: "Creating sandbox alias failed: Invalid sandbox ID."});
+            sinon.assert.calledWith(consJson, {error: "Cannot find sandbox with given ID."});
             sandbox.cli.alias.create({id: "invalidSandboxId"},"alias", false, false);
-            sinon.assert.calledWith(consError, "Creating sandbox alias failed: Invalid sandbox ID.");
+            sinon.assert.calledWith(consError, "Cannot find sandbox with given ID.");
         });
         it('Create SBX alias, sandbox not found', () => {
             sandbox.cli.alias.create({id: "unknownSandboxId"},"alias", false, true);
-            sinon.assert.calledWith(consJson, {error: "Creating sandbox alias failed: Sandbox not found."});
+            sinon.assert.calledWith(consJson, {error: "Cannot find sandbox with given ID."});
             sandbox.cli.alias.create({id: "unknownSandboxId"},"alias", false, false);
-            sinon.assert.calledWith(consError, "Creating sandbox alias failed: Sandbox not found.");
+            sinon.assert.calledWith(consError, "Cannot find sandbox with given ID.");
         });
     })
 
@@ -168,15 +182,15 @@ describe('Alias Tests for lib/sandbox.js', function() {
         });
         it('List aliases, invalid sandbox ID', () => {
             sandbox.cli.alias.list({id: "invalidSandboxId"}, true);
-            sinon.assert.calledWith(consJson, {error: "Getting sandbox aliases failed: Invalid sandbox ID."});
+            sinon.assert.calledWith(consJson, {error: "Cannot find sandbox with given ID."});
             sandbox.cli.alias.list({id: "invalidSandboxId"}, false);
-            sinon.assert.calledWith(consError, "Getting sandbox aliases failed: Invalid sandbox ID.");
+            sinon.assert.calledWith(consError, "Cannot find sandbox with given ID.");
         });
         it('List aliases, sandbox not found', () => {
             sandbox.cli.alias.list({id: "unknownSandboxId"}, true);
-            sinon.assert.calledWith(consJson, {error: "Getting sandbox aliases failed: Sandbox not found."});
+            sinon.assert.calledWith(consJson, {error: "Cannot find sandbox with given ID."});
             sandbox.cli.alias.list({id: "unknownSandboxId"}, false);
-            sinon.assert.calledWith(consError, "Getting sandbox aliases failed: Sandbox not found.");
+            sinon.assert.calledWith(consError, "Cannot find sandbox with given ID.");
         });
     });
 
@@ -201,15 +215,15 @@ describe('Alias Tests for lib/sandbox.js', function() {
         });
         it('Delete SBX alias, invalid sandbox', () => {
             sandbox.cli.alias.delete({id: "invalidSandboxId"},"s1", true);
-            sinon.assert.calledWith(consJson, {error: "Deleting sandbox alias failed: Invalid sandbox ID."});
+            sinon.assert.calledWith(consJson, {error: "Cannot find sandbox with given ID."});
             sandbox.cli.alias.delete({id: "invalidSandboxId"},"s1", false);
-            sinon.assert.calledWith(consError, "Deleting sandbox alias failed: Invalid sandbox ID.");
+            sinon.assert.calledWith(consError, "Cannot find sandbox with given ID.");
         });
         it('Delete SBX alias, sandbox not found', () => {
             sandbox.cli.alias.delete({id: "unknownSandboxId"},"s1", true);
-            sinon.assert.calledWith(consJson, {success: true});
+            sinon.assert.calledWith(consJson, {error: "Cannot find sandbox with given ID."});
             sandbox.cli.alias.delete({id: "unknownSandboxId"},"s1", false);
-            sinon.assert.calledWith(consInfo, "Success");
+            sinon.assert.calledWith(consError, "Cannot find sandbox with given ID.");
         });
     });
 


### PR DESCRIPTION
This adds support for working with On-Demand Sandboxes against the new Sandbox API Gateway. Benefits of this include:

* Avoids messing around with cluster configuration - Knowledge of the cluster your sandbox realm is provisioned on is not needed and abstracted
* Managing sandboxes provisioned on multiple clusters

Example:

You have sandboxes on realms in multiple clusters. Prior to this change you have to set the env var SANDBOX_API_HOST to the respective host name of the sandbox cluster before managing sandboxes, e.g. `sfcc-ci sandbox:list`. After that to see the sandboxes in your other realm provisioned in the other cluster, you set the env var to a different value and call `sfcc-ci sandbox:list` again.

Now, with this change you don't have to set the env var at all, but just call `sfcc-ci sandbox:list` and you are able to manage the sandboxes of both realms from both clusters.