### PR TITLE
Support for fetching audit logs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1730,6 +1730,7 @@ program
     .option('-q, --query <query>','Query to search users for')
     .option('-j, --json', 'Formats the output in json')
     .option('-s, --sortby <sortby>', 'Sort by specifying any field')
+    .option('--auditlogs', 'Returns audit logs for changes made to a user')
     .action(function(options) {
         var count = ( options.count ? options.count : null );
         var start = ( options.start ? options.start : null );
@@ -1740,6 +1741,7 @@ program
         var query = ( options.query ? JSON.parse(options.query) : null );
         var asJson = ( options.json ? options.json : false );
         var sortby = ( options.sortby ? options.sortby : null );
+        var auditlogs = ( options.auditlogs ? options.auditlogs : null );
         if ( instance && login ) {
             // get users on the instance with role
             require('./lib/user').cli.searchLocal(instance, login, query, null, null, null, null, asJson);
@@ -1748,7 +1750,7 @@ program
             require('./lib/user').cli.searchLocal(instance, login, query, role, sortby, count, start, asJson);
         } else if ( ( org && role ) || ( !org && role ) || !( org && role ) ) {
             // get users from AM
-            require('./lib/user').cli.list(org, role, login, count, asJson, sortby);
+            require('./lib/user').cli.list(org, role, login, count, asJson, sortby, auditlogs);
         } else {
             require('./lib/log').error('Ambiguous options. Please consult the help using --help.');
         }
@@ -1761,6 +1763,8 @@ program
         console.log('  be large. Use option --count to limit the number of users.');
         console.log();
         console.log('  Use --login to get details of a single user.');
+        console.log();
+        console.log('  Use option --auditlogs to return audit logs for changes made to a single user.');
         console.log();
         console.log('  Use options --org and --role, to filter users by organization, role or both.');
         console.log();
@@ -1785,6 +1789,7 @@ program
         console.log('    $ sfcc-ci user:list --instance my-instance --role Administrator');
         console.log('    $ sfcc-ci user:list --login my-login');
         console.log('    $ sfcc-ci user:list --login my-login -j');
+        console.log('    $ sfcc-ci user:list --login my-login --auditlogs');
         console.log('    $ sfcc-ci user:list --role account-admin');
         console.log('    $ sfcc-ci user:list --org my-org');
         console.log('    $ sfcc-ci user:list --org my-org --role bm-user');

--- a/cli.js
+++ b/cli.js
@@ -1566,13 +1566,15 @@ program
     .option('-o, --org <org>','Organization to get details for')
     .option('-j, --json', 'Formats the output in json')
     .option('-s, --sortby <sortby>', 'Sort by specifying any field')
+    .option('--auditlogs', 'Returns audit logs for changes made to an org')
     .action(function(options) {
         var count = ( options.count ? options.count : null );
         var all = ( options.all ? options.all : false );
         var org = ( options.org ? options.org : null );
         var asJson = ( options.json ? options.json : false );
         var sortby = ( options.sortBy ? options.sortBy : null );
-        require('./lib/org').cli.list(org, count, all, asJson, sortby);
+        var auditlogs = ( options.auditlogs ? options.auditlogs : null );
+        require('./lib/org').cli.list(org, auditlogs, count, all, asJson, sortby);
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -1583,6 +1585,7 @@ program
         console.log();
         console.log('  Use --org to get details of a single org.');
         console.log();
+        console.log('  Use option --auditlogs to return audit logs for changes made to a single org.');
         console.log('');
         console.log('  Examples:');
         console.log();
@@ -1590,6 +1593,7 @@ program
         console.log('    $ sfcc-ci org:list -c 10')
         console.log('    $ sfcc-ci org:list --org "my-org"')
         console.log('    $ sfcc-ci org:list --sortby "name"')
+        console.log('    $ sfcc-ci org:list --org "my-org" --auditlogs')
         console.log();
     });
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -118,7 +118,7 @@ module.exports.prettyPrint = prettyPrint;
 
 // tables in gray
 module.exports.table = function() {
-    console.log(info(table(arguments[0], {})));
+    console.log(info(table(arguments[0], arguments[1])));
 }
 
 // json in plain

--- a/lib/org.js
+++ b/lib/org.js
@@ -108,6 +108,37 @@ function getOrg(org, token, callback) {
 }
 
 /**
+ * Retrieves audit logs for an org
+ *
+ * @param {String} user the org
+ * @param {String} token oauth token
+ * @param {Function} callback the callback to execute, the error and the audit log are available as arguments to the callback function
+ */
+function getOrgAuditLogs(org, token, callback) {
+    // build the request options
+    var options = getOptions(API_BASE + '/organizations/' + org.id + '/audit-log-records',
+        token || auth.getToken(), 'GET');
+
+    // do the request
+    request(options, function (err, res, body) {
+        var errback = captureCommonErrors(err, res);
+        if ( errback ) {
+            callback(errback);
+            return;
+        } else if ( res.statusCode >= 400 ) {
+            callback(new Error(util.format('Getting audit logs failed: %s', res.statusCode)));
+            return;
+        } else if ( err ) {
+            callback(new Error(util.format('Getting audit logs failed: %s', err)));
+            return;
+        }
+
+        // do the callback with the body
+        callback(undefined, body, body.content);
+    });
+}
+
+/**
  * Transforms the API org representation to an external format. Certain properties are
  * transformed into an object representation.
  *
@@ -163,14 +194,91 @@ module.exports.cli = {
      * Lists all org eligible to manage
      *
      * @param {String} orgId the org id or null, if all orgs should be retrieved
+     * @param {Boolean} auditlogs optional flag to return audit logs for an org, false by default
      * @param {Number} count the max count of list items
      * @param {Boolean} all whether to return all orgs, false by default
      * @param {Boolean} asJson optional flag to force output in json, false by default
      * @param {String} sortBy optional field to sort the list of orgs by
      */
-    list : function(orgId, count, all, asJson, sortBy) {
+    list : function(orgId, auditlogs, count, all, asJson, sortBy) {
         // get details of a single org if org was passed
         if ( typeof(orgId) !== 'undefined' && orgId !== null ) {
+            // get audit logs
+            // define the callback
+            var getAuditLogsCallback = function(err, result, list) {
+                if (err) {
+                    if (typeof callback !== 'undefined') {
+                        callback(err, undefined);
+                        return;
+                    }
+
+                    if (asJson) {
+                        console.json({error: err.message});
+                    } else {
+                        console.error(err.message);
+                    }
+                    return;
+                }
+
+                if (sortBy) {
+                    list = require('./json').sort(list, sortBy);
+                }
+
+                if (typeof callback !== 'undefined') {
+                    callback(undefined, list);
+                    return;
+                }
+
+                if (asJson) {
+                    // if sorted, then only provide the list of the current page
+                    if (sortBy) {
+                        console.json(list);
+                    } else {
+                        console.json(result);
+                    }
+                    return;
+                }
+
+                if (list.length === 0) {
+                    console.info('No audit records found');
+                    return;
+                }
+
+                // table fields
+                var data = [['timestamp','authorDisplayName', 'authorEmail','eventType','eventMessage']];
+                for (var i of list) {
+                    data.push([i.timestamp, i.authorDisplayName, ( i.authorEmail ? i.authorEmail : 'n/a' ),
+                        i.eventType, i.eventMessage]);
+                }
+
+                console.table(data, {
+                    columns : {
+                        4 : { width : 100 }
+                    }
+                });
+            };
+
+            // in case org audit logs are requested, resolve org id first
+            if ( auditlogs ) {
+                getOrg(orgId, undefined, function(err, org) {
+                    if (err) {
+                        if (typeof callback !== 'undefined') {
+                            callback(err, undefined);
+                            return;
+                        }
+
+                        if (asJson) {
+                            console.json({error: err.message});
+                        } else {
+                            console.error(err.message);
+                        }
+                        return;
+                    }
+                    getOrgAuditLogs(org, undefined, getAuditLogsCallback);
+                });
+                return;
+            }
+            // just return org details
             getOrg(orgId, undefined, function(err, org) {
                 if (err) {
                     console.error(err.message);

--- a/lib/user.js
+++ b/lib/user.js
@@ -103,7 +103,7 @@ function getOptions(path, token, method) {
  *
  * @param {String} login the login of the user
  * @param {String} token oauth token
- * @param {Function} callback the callback to execute, the error and the user are available as arguments to the callback function
+ * @param {Function} callback the callback to execute, the error and the audit logs are available as arguments to the callback function
  */
 function getUser(login, token, callback) {
     // build the request options
@@ -129,6 +129,36 @@ function getUser(login, token, callback) {
         // do the callback with the body
         // filter some properties before returning
         callback(undefined, toExternalUser(body));
+    });
+}
+
+/**
+ * Retrieves audit logs for a user
+ *
+ * @param {String} user the user
+ * @param {String} token oauth token
+ * @param {Function} callback the callback to execute, the error and the user are available as arguments to the callback function
+ */
+function getUserAuditLogs(user, token, callback) {
+    // build the request options
+    var options = getOptions(API_BASE + '/users/' + user.id + '/audit-log-records', token || auth.getToken(), 'GET');
+
+    // do the request
+    request(options, function (err, res, body) {
+        var errback = captureCommonErrors(err, res);
+        if ( errback ) {
+            callback(errback);
+            return;
+        } else if ( res.statusCode >= 400 ) {
+            callback(new Error(util.format('Getting audit logs failed: %s', res.statusCode)));
+            return;
+        } else if ( err ) {
+            callback(new Error(util.format('Getting audit logs failed: %s', err)));
+            return;
+        }
+
+        // do the callback with the body
+        callback(undefined, body, body.content);
     });
 }
 
@@ -1037,12 +1067,89 @@ module.exports.cli = {
      * @param {Number} count the max count of list items
      * @param {Boolean} asJson optional flag to force output in json, false by default
      * @param {String} sortBy optional field to sort the list of users by
+     * @param {Boolean} auditlogs optional flag to return audit logs for a user, false by default
      * @param {String} token oauth token
      * @param {Function} callback callback function to call when called through the Javascript API
      */
-    list : function(org, role, login, count, asJson, sortBy, token, callback) {
+    list : function(org, role, login, count, asJson, sortBy, auditlogs, token, callback) {
         // get details of a single user if login was passed
         if ( typeof(login) !== 'undefined' && login !== null ) {
+            // get audit logs
+            // define the callback
+            var getAuditLogsCallback = function(err, result, list) {
+                if (err) {
+                    if (typeof callback !== 'undefined') {
+                        callback(err, undefined);
+                        return;
+                    }
+
+                    if (asJson) {
+                        console.json({error: err.message});
+                    } else {
+                        console.error(err.message);
+                    }
+                    return;
+                }
+
+                if (sortBy) {
+                    list = require('./json').sort(list, sortBy);
+                }
+
+                if (typeof callback !== 'undefined') {
+                    callback(undefined, list);
+                    return;
+                }
+
+                if (asJson) {
+                    // if sorted, then only provide the list of the current page
+                    if (sortBy) {
+                        console.json(list);
+                    } else {
+                        console.json(result);
+                    }
+                    return;
+                }
+
+                if (list.length === 0) {
+                    console.info('No audit records found');
+                    return;
+                }
+
+                // table fields
+                var data = [['timestamp','authorDisplayName', 'authorEmail','eventType','eventMessage']];
+                for (var i of list) {
+                    data.push([i.timestamp, i.authorDisplayName, ( i.authorEmail ? i.authorEmail : 'n/a' ),
+                        i.eventType, i.eventMessage]);
+                }
+
+                console.table(data, {
+                    columns : {
+                        4 : { width : 100 }
+                    }
+                });
+            };
+
+            // in case user audit logs are requested, resolve user id first
+            if ( auditlogs ) {
+                getUser(login, token, function(err, user) {
+                    if (err) {
+                        if (typeof callback !== 'undefined') {
+                            callback(err, undefined);
+                            return;
+                        }
+
+                        if (asJson) {
+                            console.json({error: err.message});
+                        } else {
+                            console.error(err.message);
+                        }
+                        return;
+                    }
+                    getUserAuditLogs(user, token, getAuditLogsCallback);
+                });
+                return;
+            }
+            // just return user details
             getUser(login, token, function(err, user) {
                 if (err) {
                     if (typeof callback !== 'undefined') {
@@ -1923,7 +2030,7 @@ module.exports.api = {
      * @param {String} token oauth token
      */
     list: (org, role, login, count, sortBy, token) => new Promise((resolve, reject) => {
-        module.exports.cli.list(org, role, login, count, false, sortBy, token, (err, result) => {
+        module.exports.cli.list(org, role, login, count, false, sortBy, false, token, (err, result) => {
             if (err) {
                 reject(err);
                 return;

--- a/test/unit/org.js
+++ b/test/unit/org.js
@@ -267,7 +267,7 @@ describe('Tests for lib/org.js', function() {
                     'json' : jsonStub
                 }
             });
-            org.cli.list('myorg', null, null, true, undefined);
+            org.cli.list('myorg', false, null, null, true, undefined);
 
             const logArgs = jsonStub.getCall(0).args;
             expect(logArgs[0]).to.eql({id:1,name:"myorg"});


### PR DESCRIPTION
This adds support for fetching audit logs for changes made to a user and changes made to an organization in Account Manager. The flag `--auditlogs` has been added to commands `sfcc-ci user:list --login <login>` and `sfcc-ci org:list --org <org>`. Passing the flag will return the audit logs for the changes made to these objects.

Example commands:

* `sfcc-ci user:list --login <login> --auditlogs`
* `sfcc-ci org:list --org <org> --auditlogs`