### PR TITLE
Migrate to @snyk/protect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,11 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@snyk/protect": {
+      "version": "1.1110.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1110.0.tgz",
+      "integrity": "sha512-fey2HEdhCm6qD23f2sZdFu9B4ckgCgpLIDgUGFbRZhhYaF8sUhQSZe5SAegNU7npDHO52jz+J7CJjGbsk5f1ow=="
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -2565,11 +2570,6 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         }
       }
-    },
-    "snyk": {
-      "version": "1.1073.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1073.0.tgz",
-      "integrity": "sha512-THPprC+HUcP+AZTQKwSljW1NwzHV/F8NWFGgemWR3QNfEgWBk22CEuEdBFZuTy6HykSe8IrMWfPvT+3yJyrgmQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:unit:coverage": "npx nyc@15.1.0 mocha test/unit",
     "test:functional:cli": "bin/test-cli.sh",
     "dist": "npx pkg@5.5.2 . --out-path dist/",
-    "snyk-protect": "snyk protect",
+    "snyk-protect": "snyk-protect",
     "prepare": "npm run snyk-protect"
   },
   "repository": {
@@ -24,6 +24,7 @@
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/SalesforceCommerceCloud/sfcc-ci#readme",
   "dependencies": {
+    "@snyk/protect": "^1.1110.0",
     "archiver": "^5.3.1",
     "chalk": "^2.4.1",
     "colors": "1.4.0",
@@ -31,16 +32,15 @@
     "conf": "^4.0.2",
     "del": "^5.1.0",
     "dotenv": "^8.6.0",
+    "generate-password": "^1.7.0",
     "globby": "^11.1.0",
     "inquirer": "^7.3.3",
     "jsondiffpatch": "^0.4.1",
     "jsonwebtoken": "^9.0.0",
     "node-sha1": "^1.0.1",
     "open": "^6.4.0",
-    "generate-password": "^1.7.0",
     "request": "^2.88.0",
     "request-debug": "^0.2.0",
-    "snyk": "^1.1073.0",
     "table": "^6.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Migrate usage of `snyk protect` to `snyk-protect`

More details in:

* https://updates.snyk.io/snyk-wizard-and-snyk-protect-removal-224137
* https://github.com/snyk/cli/tree/master/packages/snyk-protect?utm_medium=CLI&utm_source=Snyk-CLI#migrating-from-snyk-protect-to-snykprotect