### PR TITLE
Add scheduler for Realm and Sandbox 

### DIFF
--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -15,10 +15,10 @@ if [ $? -eq 1 ]; then
 	exit 1
 fi
 
-# reset to track the time elapsed 
+# reset to track the time elapsed
 SECONDS=0
 
-# pass parameters in the following order: 
+# pass parameters in the following order:
 # $ bin/test-cli.sh <CLIENT_ID> <CLIENT_SECRET> <USER> <USER_PW> <HOST> <SANDBOX_REALM> <TEST_ORG> <TEST_USER>
 
 # mapping input parameters
@@ -41,7 +41,7 @@ fi
 # check on realm
 if [ "$ARG_SANDBOX_REALM" = "" ]; then
     echo -e "Realm for sandbox API unknown."
-	echo 
+	echo
 	exit 1
 fi
 
@@ -444,8 +444,8 @@ else
 	echo -e "\t> FAILED"
 	exit 1
 fi
-echo "Testing command ´sfcc-ci sandbox:realm:update --realm <realm> --default-sandbox-ttl 100 --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}':"
-node ./cli.js sandbox:realm:update --realm $ARG_SANDBOX_REALM --default-sandbox-ttl 100 --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'
+echo "Testing command ´sfcc-ci sandbox:realm:update --realm <realm>  --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}':"
+node ./cli.js sandbox:realm:update --realm $ARG_SANDBOX_REALM --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'
 if [ $? -eq 0 ]; then
     echo -e "\t> OK"
 else
@@ -453,8 +453,8 @@ else
 	exit 1
 fi
 
-echo "Testing command ´sfcc-ci sandbox:realm:update --realm <realm> --default-sandbox-ttl 100 --start-scheduler 'null' --stop-scheduler 'null':"
-node ./cli.js sandbox:realm:update --realm $ARG_SANDBOX_REALM --default-sandbox-ttl 100 --start-scheduler 'null' --stop-scheduler 'null'
+echo "Testing command ´sfcc-ci sandbox:realm:update --realm <realm>  --start-scheduler 'null' --stop-scheduler 'null':"
+node ./cli.js sandbox:realm:update --realm $ARG_SANDBOX_REALM  --start-scheduler 'null' --stop-scheduler 'null'
 if [ $? -eq 0 ]; then
     echo -e "\t> OK"
 else
@@ -599,7 +599,7 @@ else
 	exit 1
 fi
 
-echo "Testing command ´sfcc-ci sandbox:create --realm <realm> --ttl 1 ´ --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}':"
+echo "Testing command ´sfcc-ci sandbox:create --realm <realm> --ttl 1  --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}':"
 node ./cli.js sandbox:create --realm $ARG_SANDBOX_REALM --ttl 1  --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'
 if [ $? -eq 0 ]; then
     echo -e "\t> OK"

--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -444,7 +444,23 @@ else
 	echo -e "\t> FAILED"
 	exit 1
 fi
+echo "Testing command ´sfcc-ci sandbox:realm:update --realm <realm> --default-sandbox-ttl 100 --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}':"
+node ./cli.js sandbox:realm:update --realm $ARG_SANDBOX_REALM --default-sandbox-ttl 100 --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
 
+echo "Testing command ´sfcc-ci sandbox:realm:update --realm <realm> --default-sandbox-ttl 100 --start-scheduler 'null' --stop-scheduler 'null':"
+node ./cli.js sandbox:realm:update --realm $ARG_SANDBOX_REALM --default-sandbox-ttl 100 --start-scheduler 'null' --stop-scheduler 'null'
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
 ###############################################################################
 ###### Testing ´sfcc-ci sandbox:ips´
 ###############################################################################
@@ -576,6 +592,15 @@ fi
 
 echo "Testing command ´sfcc-ci sandbox:create --realm <realm> --ttl 1 --sync´:"
 node ./cli.js sandbox:create --realm $ARG_SANDBOX_REALM --ttl 1 --sync
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
+echo "Testing command ´sfcc-ci sandbox:create --realm <realm> --ttl 1 ´ --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}':"
+node ./cli.js sandbox:create --realm $ARG_SANDBOX_REALM --ttl 1  --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'
 if [ $? -eq 0 ]; then
     echo -e "\t> OK"
 else
@@ -734,6 +759,23 @@ else
 	exit 1
 fi
 
+echo "Testing command ´sfcc-ci sandbox:update <sandbox> --ttl 2 --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'´:"
+node ./cli.js sandbox:update --sandbox $TEST_NEW_SANDBOX_ID --ttl 1 --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
+echo "Testing command ´sfcc-ci sandbox:update <sandbox> --ttl 2 --start-scheduler 'null' --stop-scheduler 'null'´:"
+node ./cli.js sandbox:update --sandbox $TEST_NEW_SANDBOX_ID --ttl 1 --start-scheduler 'null' --stop-scheduler 'null'
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
 ###############################################################################
 ###### Testing ´sfcc-ci sandbox:alias:*´
 ###############################################################################

--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -759,8 +759,8 @@ else
 	exit 1
 fi
 
-echo "Testing command ´sfcc-ci sandbox:update <sandbox> --ttl 2 --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'´:"
-node ./cli.js sandbox:update --sandbox $TEST_NEW_SANDBOX_ID --ttl 1 --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'
+echo "Testing command ´sfcc-ci sandbox:update <sandbox> --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'´:"
+node ./cli.js sandbox:update --sandbox $TEST_NEW_SANDBOX_ID  --start-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}' --stop-scheduler '{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}'
 if [ $? -eq 0 ]; then
     echo -e "\t> OK"
 else
@@ -768,8 +768,8 @@ else
 	exit 1
 fi
 
-echo "Testing command ´sfcc-ci sandbox:update <sandbox> --ttl 2 --start-scheduler 'null' --stop-scheduler 'null'´:"
-node ./cli.js sandbox:update --sandbox $TEST_NEW_SANDBOX_ID --ttl 1 --start-scheduler 'null' --stop-scheduler 'null'
+echo "Testing command ´sfcc-ci sandbox:update <sandbox>  --start-scheduler 'null' --stop-scheduler 'null'´:"
+node ./cli.js sandbox:update --sandbox $TEST_NEW_SANDBOX_ID  --start-scheduler 'null' --stop-scheduler 'null'
 if [ $? -eq 0 ]; then
     echo -e "\t> OK"
 else

--- a/cli.js
+++ b/cli.js
@@ -479,8 +479,8 @@ program
     .option('-r, --realm <realm>', 'Realm to update')
     .option('-m, --max-sandbox-ttl <maxSandboxTTL>', 'Maximum number of hours a sandbox can live in the realm')
     .option('-d, --default-sandbox-ttl <defaultSandboxTTL>', 'Number of hours a sandbox lives in the realm by default')
-    .option('-st, --start-scheduler <startScheduler>', 'Start schedule for all sandboxes under this realm')
-    .option('-sp, --stop-scheduler <stopScheduler>', 'Stop schedule for all sandboxes under this realm')
+    .option('--start-scheduler <startScheduler>', 'Start schedule for all sandboxes under this realm')
+    .option('--stop-scheduler <stopScheduler>', 'Stop schedule for all sandboxes under this realm')
     .option('-j, --json', 'Formats the output in json')
     .action(function (options) {
         var realm = (options.realm ? options.realm : null);
@@ -521,7 +521,7 @@ program
         console.log('  provisioning (must adhere to the maximum TTL quota).');
         console.log();
         console.log('  Use --start-scheduler and --stop-scheduler to update the start and stop schedule for the ');
-        console.log('  sandbox. You can use the value \'null\' to remove the existing schedule from the sandbox');
+        console.log('  realm. You can use the value \'null\' to remove the existing schedule from the sandbox');
         console.log();
         console.log();
         console.log('  Examples:');
@@ -586,8 +586,8 @@ program
     .option('-r, --realm <realm>','Realm to create the sandbox for')
     .option('-t, --ttl <hours>','Number of hours the sandbox will live')
     .option('--auto-scheduled', 'Sets the sandbox as being auto scheduled')
-    .option('-st, --start-scheduler <startScheduler>', 'Start schedule for the sandbox')
-    .option('-sp, --stop-scheduler <stopScheduler>', 'Stop schedule for the sandbox')
+    .option('--start-scheduler <startScheduler>', 'Start schedule for the sandbox')
+    .option('--stop-scheduler <stopScheduler>', 'Stop schedule for the sandbox')
     .option('-p, --profile <profile>','Resource profile used for the sandbox, "medium" is the default')
     .option('--ocapi-settings <json>','Additional OCAPI settings applied to the sandbox')
     .option('--webdav-settings <json>','Additional WebDAV permissions applied to the sandbox')
@@ -637,7 +637,7 @@ program
         console.log('  schedule configured at sandbox realm level. By default or if omitted the sandbox is not auto');
         console.log('  scheduled.');
         console.log();
-        console.log('  Use --start-scheduler and --stop-scheduler to update the start and stop schedule for the ');
+        console.log('  Use --start-scheduler and --stop-scheduler to add the start and stop schedule for the ');
         console.log('  sandbox.');
         console.log();
         console.log('  Use the optional --profile <profile> to set the resource allocation for the sandbox, "medium"');
@@ -755,8 +755,8 @@ program
     .option('-s, --sandbox <id>','sandbox to update')
     .option('-t, --ttl <hours>','number of hours to add to the sandbox lifetime')
     .option('--auto-scheduled <flag>','Sets the sandbox as being auto scheduled')
-    .option('-st, --start-scheduler <startScheduler>', 'Start schedule for the sandbox')
-    .option('-sp, --stop-scheduler <stopScheduler>', 'Stop schedule for the sandbox')
+    .option('--start-scheduler <startScheduler>', 'Start schedule for the sandbox')
+    .option('--stop-scheduler <stopScheduler>', 'Stop schedule for the sandbox')
     .description('Update a sandbox')
     .action(function(options) {
         var sandbox_id = ( options.sandbox ? options.sandbox : null );

--- a/cli.js
+++ b/cli.js
@@ -476,21 +476,40 @@ program
 program
     .command('sandbox:realm:update')
     .description('Update realm settings')
-    .option('-r, --realm <realm>','Realm to update')
-    .option('-m, --max-sandbox-ttl <maxSandboxTTL>','Maximum number of hours a sandbox can live in the realm')
-    .option('-d, --default-sandbox-ttl <defaultSandboxTTL>','Number of hours a sandbox lives in the realm by default')
-    .option('-j, --json','Formats the output in json')
-    .action(function(options) {
-        var realm = ( options.realm ? options.realm : null );
+    .option('-r, --realm <realm>', 'Realm to update')
+    .option('-m, --max-sandbox-ttl <maxSandboxTTL>', 'Maximum number of hours a sandbox can live in the realm')
+    .option('-d, --default-sandbox-ttl <defaultSandboxTTL>', 'Number of hours a sandbox lives in the realm by default')
+    .option('-st, --start-scheduler <startScheduler>', 'Start schedule for all sandboxes under this realm')
+    .option('-sp, --stop-scheduler <stopScheduler>', 'Stop schedule for all sandboxes under this realm')
+    .option('-j, --json', 'Formats the output in json')
+    .action(function (options) {
+        var realm = (options.realm ? options.realm : null);
         if (!realm) {
             this.missingArgument('realm');
             return;
         }
-        var maxSandboxTTL = ( options.maxSandboxTtl ? parseInt(options.maxSandboxTtl) : false );
-        var defaultSandboxTTL = ( options.defaultSandboxTtl ? parseInt(options.defaultSandboxTtl) : false );
-        var asJson = ( options.json ? options.json : false );
-        require('./lib/sandbox').cli.realm.update(realm, maxSandboxTTL, defaultSandboxTTL, asJson);
-    }).on('--help', function() {
+        var maxSandboxTTL = (options.maxSandboxTtl ? parseInt(options.maxSandboxTtl) : false);
+        var defaultSandboxTTL = (options.defaultSandboxTtl ? parseInt(options.defaultSandboxTtl) : false);
+        var scheduleOk = true;
+        try {
+            var startScheduler = options.startScheduler ?
+                (options.startScheduler === "null" ? "null" : JSON.parse(options.startScheduler)) : null;
+            var stopScheduler = options.stopScheduler ?
+                (options.stopScheduler === "null" ? "null" : JSON.parse(options.stopScheduler)) : null;
+        } catch (objError) {
+            scheduleOk = false;
+            if (objError instanceof SyntaxError) {
+                log.error(objError.name + ' : Invalid JSON format for scheduler. Use -h,--help for help.');
+            } else {
+                log.error(objError.message);
+            }
+        }
+        var asJson = (options.json ? options.json : false);
+        if (scheduleOk) {
+            require('./lib/sandbox').cli.realm.update(realm, maxSandboxTTL, defaultSandboxTTL, startScheduler,
+                stopScheduler, asJson);
+        }
+    }).on('--help', function () {
         console.log('');
         console.log('  Details:');
         console.log();
@@ -501,10 +520,19 @@ program
         console.log('  update the number of hours a sandbox lives in the realm when no TTL was given upon');
         console.log('  provisioning (must adhere to the maximum TTL quota).');
         console.log();
+        console.log('  Use --start-scheduler and --stop-scheduler to update the start and stop schedule for the ');
+        console.log('  sandbox. You can use the value \'null\' to remove the existing schedule from the sandbox');
+        console.log();
+        console.log();
         console.log('  Examples:');
         console.log();
         console.log('    $ sfcc-ci sandbox:realm:update --realm zzzz --max-sandbox-ttl 72');
         console.log('    $ sfcc-ci sandbox:realm:update --realm zzzz --default-sandbox-ttl 24');
+        console.log('    $ sfcc-ci sandbox:realm:update --realm zzzz --default-sandbox-ttl 24');
+        console.log('    $ sfcc-ci sandbox:realm:update --realm zzzz --start-scheduler ' +
+            '\'{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}\'');
+        console.log('    $ sfcc-ci sandbox:realm:update --realm zzzz --stop-scheduler ' +
+            '\'{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}\'');
         console.log();
     });
 
@@ -558,6 +586,8 @@ program
     .option('-r, --realm <realm>','Realm to create the sandbox for')
     .option('-t, --ttl <hours>','Number of hours the sandbox will live')
     .option('--auto-scheduled', 'Sets the sandbox as being auto scheduled')
+    .option('-st, --start-scheduler <startScheduler>', 'Start schedule for the sandbox')
+    .option('-sp, --stop-scheduler <stopScheduler>', 'Stop schedule for the sandbox')
     .option('-p, --profile <profile>','Resource profile used for the sandbox, "medium" is the default')
     .option('--ocapi-settings <json>','Additional OCAPI settings applied to the sandbox')
     .option('--webdav-settings <json>','Additional WebDAV permissions applied to the sandbox')
@@ -577,8 +607,22 @@ program
         var alias = ( options.setAlias ? options.setAlias : null );
         var ocapiSettings = ( options.ocapiSettings ? options.ocapiSettings : null );
         var webdavSettings = ( options.webdavSettings ? options.webdavSettings : null );
-        require('./lib/sandbox').cli.create(realm, alias, ttl, profile, autoScheduled, ocapiSettings, webdavSettings,
-            asJson, sync, setAsDefault);
+        var scheduleOk = true;
+        try {
+            var startScheduler = options.startScheduler ? JSON.parse(options.startScheduler) : null;
+            var stopScheduler = options.stopScheduler ? JSON.parse(options.stopScheduler) : null;
+        } catch (objError) {
+            scheduleOk = false;
+            if (objError instanceof SyntaxError) {
+                log.error(objError.name + ' : Invalid JSON format for scheduler. Use -h,--help for help.');
+            } else {
+                log.error(objError.message);
+            }
+        }
+        if (scheduleOk) {
+            require('./lib/sandbox').cli.create(realm, alias, ttl, profile, autoScheduled, startScheduler,
+                stopScheduler, ocapiSettings, webdavSettings, asJson, sync, setAsDefault);
+        }
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -592,6 +636,9 @@ program
         console.log('  The --auto-scheduled flag controls if the sandbox is being auto scheduled according to the');
         console.log('  schedule configured at sandbox realm level. By default or if omitted the sandbox is not auto');
         console.log('  scheduled.');
+        console.log();
+        console.log('  Use --start-scheduler and --stop-scheduler to update the start and stop schedule for the ');
+        console.log('  sandbox.');
         console.log();
         console.log('  Use the optional --profile <profile> to set the resource allocation for the sandbox, "medium"');
         console.log('  is the default. Be careful, more powerful profiles consume more credits. Supported values');
@@ -629,6 +676,11 @@ program
         console.log('    $ sfcc-ci sandbox:create -r my-realm --ttl 6');
         console.log('    $ sfcc-ci sandbox:create -r my-realm --auto-scheduled');
         console.log('    $ sfcc-ci sandbox:create -r my-realm -p large');
+        console.log('    $ sfcc-ci sandbox:create -r my-realm --start-scheduler ' +
+            '\'{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}\'');
+        console.log('    $ sfcc-ci sandbox:create -r my-realm --stop-scheduler ' +
+            '\'{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}\'');
+        console.log();
         console.log();
     });
 
@@ -703,6 +755,8 @@ program
     .option('-s, --sandbox <id>','sandbox to update')
     .option('-t, --ttl <hours>','number of hours to add to the sandbox lifetime')
     .option('--auto-scheduled <flag>','Sets the sandbox as being auto scheduled')
+    .option('-st, --start-scheduler <startScheduler>', 'Start schedule for the sandbox')
+    .option('-sp, --stop-scheduler <stopScheduler>', 'Stop schedule for the sandbox')
     .description('Update a sandbox')
     .action(function(options) {
         var sandbox_id = ( options.sandbox ? options.sandbox : null );
@@ -721,7 +775,23 @@ program
         var ttl = ( options.ttl ? parseInt(options.ttl) : null );
         var autoScheduled = ( options.autoScheduled !== null ?
             ( options.autoScheduled === 'true' ? true : false ) : null );
-        require('./lib/sandbox').cli.update(spec, ttl, autoScheduled, false);
+        var scheduleOk = true;
+        try {
+            var startScheduler = options.startScheduler ?
+                (options.startScheduler === "null" ? "null" : JSON.parse(options.startScheduler)) : null;
+            var stopScheduler = options.stopScheduler ?
+                (options.stopScheduler === "null" ? "null" : JSON.parse(options.stopScheduler)) : null;
+        } catch (objError) {
+            scheduleOk = false;
+            if (objError instanceof SyntaxError) {
+                log.error(objError.name + ' : Invalid JSON format for scheduler. Use -h,--help for help.');
+            } else {
+                log.error(objError.message);
+            }
+        }
+        if (scheduleOk) {
+            require('./lib/sandbox').cli.update(spec, ttl, autoScheduled, false, startScheduler, stopScheduler);
+        }
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -733,6 +803,9 @@ program
         console.log('  The --auto-scheduled flag controls if the sandbox is being autoscheduled according to the');
         console.log('  schedule configured at sandbox realm level.');
         console.log();
+        console.log('  Use --start-scheduler and --stop-scheduler to update the start and stop schedule for the ');
+        console.log('  sandbox. You can use the value \'null\' to remove the existing schedule from the sandbox');
+        console.log();
         console.log('  The sandbox to update must be identified by its id. Use may use `sfcc-ci sandbox:list` to');
         console.log('  identify the id of your sandboxes.');
         console.log();
@@ -743,6 +816,10 @@ program
         console.log('    $ sfcc-ci sandbox:update --sandbox my-sandbox-id --ttl 8');
         console.log('    $ sfcc-ci sandbox:update --sandbox my-sandbox-id --auto-scheduled true');
         console.log('    $ sfcc-ci sandbox:update --sandbox my-sandbox-id --auto-scheduled false');
+        console.log('    $ sfcc-ci sandbox:update --sandbox my-sandbox-id --start-scheduler ' +
+            '\'{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"08:00:00+03:00"}\'');
+        console.log('    $ sfcc-ci sandbox:update --sandbox my-sandbox-id --stop-scheduler ' +
+            '\'{"weekdays":["MONDAY","TUESDAY","WEDNESDAY","THURSDAY","FRIDAY"],"time":"19:00:00Z"}\'');
         console.log();
     });
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -683,7 +683,7 @@ function updateSandbox(id, ttl, autoScheduled, startScheduler, stopScheduler, ca
             options['body']['startScheduler'] = startScheduler;
         }
     }
-    
+
     if (stopScheduler) {
         if ( stopScheduler === "null" ) {
             options['body']['stopScheduler'] = null;

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -412,7 +412,7 @@ function getRealm(realmID, topic, callback) {
  * @param {Number} defaultSandboxTTL the new default sandbox ttl
  * @param {Function} callback the callback to execute, the error and the realm details are available as arguments to the callback function
  */
-function updateRealm(realmID, maxSandboxTTL, defaultSandboxTTL, callback) {
+function updateRealm(realmID, maxSandboxTTL, defaultSandboxTTL, startScheduler, stopScheduler, callback) {
     // build the request options
     var options = ocapi.getOptions('PATCH', API_BASE + '/realms/' + realmID + '/configuration');
 
@@ -426,12 +426,21 @@ function updateRealm(realmID, maxSandboxTTL, defaultSandboxTTL, callback) {
         options['body']['sandbox']['sandboxTTL']['defaultValue'] = defaultSandboxTTL.toFixed();
     }
 
-    // TODO set schedule here
-    //if (schedule) {
-    //    options['body']['sandbox']['stopScheduler'] = schedule['stopScheduler'] ? schedule['stopScheduler'] : null;
-    //    options['body']['sandbox']['startScheduler'] = schedule['startScheduler'] ? schedule['startScheduler'] : null;
-    //}
-
+    //We need to set explicit "null" to remove the existing schedule
+    if (startScheduler) {
+        if ( startScheduler === "null" ) {
+            options['body']['sandbox']['startScheduler'] = null;
+        } else {
+            options['body']['sandbox']['startScheduler'] = startScheduler;
+        }
+    }
+    if (stopScheduler) {
+        if ( stopScheduler === "null" ) {
+            options['body']['sandbox']['stopScheduler'] = null;
+        } else {
+            options['body']['sandbox']['stopScheduler'] = stopScheduler;
+        }
+    }
     ocapi.retryableCall('PATCH', options, function(err, res) {
         var errback = captureCommonErrors(err, res);
         if ( !errback ) {
@@ -517,12 +526,14 @@ function lookupSandbox(spec, callback) {
  * @param {String} ttl the ttl of the sandbox in hours
  * @param {String} profile the resource profile of the sandbox
  * @param {Boolean} autoScheduled sets the sandbox as auto scheduled
+ * @param {String} startScheduler start schedule for the sandbox
+ * @param {String} stopScheduler stop schedule for the sandbox
  * @param {String} additionalOcapiSettings JSON string holding additonal OCAPI settings to pass
  * @param {String} additionalWebdavSettings JSON string holding additonal WebDAV permissions to pass
  * @param {Function} callback the callback to execute, the error and the created sandbox are available as arguments to the callback function
  */
-function createSandbox(realm, ttl, profile, autoScheduled, additionalOcapiSettings, additionalWebdavSettings,
-    callback) {
+function createSandbox(realm, ttl, profile, autoScheduled, startScheduler, stopScheduler,
+    additionalOcapiSettings, additionalWebdavSettings, callback) {
     if (!realm && dwjson['realm']) {
         realm = dwjson['realm'];
         console.debug('Using realm id %s from dw.json at %s', dwjson['realm'], process.cwd());
@@ -576,6 +587,14 @@ function createSandbox(realm, ttl, profile, autoScheduled, additionalOcapiSettin
     // set auto scheduled, if passed
     if (autoScheduled) {
         options['body']['autoScheduled'] = true;
+    }
+
+    if (startScheduler) {
+        options['body']['startScheduler'] = startScheduler;
+    }
+
+    if (stopScheduler) {
+        options['body']['stopScheduler'] = stopScheduler;
     }
 
     // the profile, if passed
@@ -637,9 +656,11 @@ function getSandbox(id, topic, callback) {
  * @param {String} id the sandbox update
  * @param {Number} ttl the ttl to update (value will not overwrite the existing ttl, but added to the ttl = prolonged)
  * @param {Boolean} autoScheduled sets the sandbox as auto scheduled
+ * @param {String} startScheduler start schedule for the sandbox
+ * @param {String} stopScheduler stop schedule for the sandbox
  * @param {Function} callback the callback to execute, the error and the sandbox details are available as arguments to the callback function
  */
-function updateSandbox(id, ttl, autoScheduled, callback) {
+function updateSandbox(id, ttl, autoScheduled, startScheduler, stopScheduler, callback) {
     // build the request options
     var options = ocapi.getOptions('PATCH', API_SANDBOXES + '/' + id);
     options['body'] = {};
@@ -652,6 +673,23 @@ function updateSandbox(id, ttl, autoScheduled, callback) {
     // sets auto scheduled
     if ( autoScheduled !== null ) {
         options['body']['autoScheduled'] = autoScheduled;
+    }
+
+    //We need to set explicit "null" to remove the existing schedule
+    if (startScheduler) {
+        if ( startScheduler === "null" ) {
+            options['body']['startScheduler'] = null;
+        } else {
+            options['body']['startScheduler'] = startScheduler;
+        }
+    }
+    
+    if (stopScheduler) {
+        if ( stopScheduler === "null" ) {
+            options['body']['stopScheduler'] = null;
+        } else {
+            options['body']['stopScheduler'] = stopScheduler;
+        }
     }
 
     ocapi.retryableCall('PATCH', options, function(err, res) {
@@ -926,8 +964,11 @@ module.exports.cli = {
          * @param {String} realm realm to update
          * @param {Number} maxSandboxTTL max number of hours a sandbox can live in the realm
          * @param {Number} defaultSandboxTTL number of hours a sandbox lives in the realm by default
-         */
-        update : function(realm, maxSandboxTTL, defaultSandboxTTL, asJson) {
+         * @param {String} startScheduler start schedule for all sandboxes under this realm
+         * @param {String} stopScheduler stop schedule for all sandboxes under this realm
+         * @param {Boolean} asJson optional flag to force output in json, false by default
+          */
+        update : function(realm, maxSandboxTTL, defaultSandboxTTL, startScheduler, stopScheduler, asJson) {
             // lookup realm to update
             getRealm(realm, null, function (err, realm) {
                 if (err) {
@@ -937,21 +978,22 @@ module.exports.cli = {
                 }
 
                 // realm found, now update
-                updateRealm(realm.id, maxSandboxTTL, defaultSandboxTTL, function(err, updatedRealm) {
-                    var result = {};
-                    if (err) {
-                        result['error'] = err.message;
-                    } else {
-                        result = updatedRealm;
-                    }
-                    if (asJson) {
-                        console.json(result);
-                    } else if (err) {
-                        console.error(err.message);
-                    } else {
-                        console.prettyPrint(result);
-                    }
-                });
+                updateRealm(realm.id, maxSandboxTTL, defaultSandboxTTL,
+                    startScheduler, stopScheduler, function (err, updatedRealm) {
+                        var result = {};
+                        if (err) {
+                            result['error'] = err.message;
+                        } else {
+                            result = updatedRealm;
+                        }
+                        if (asJson) {
+                            console.json(result);
+                        } else if (err) {
+                            console.error(err.message);
+                        } else {
+                            console.prettyPrint(result);
+                        }
+                    });
             });
         }
     },
@@ -1047,172 +1089,177 @@ module.exports.cli = {
      * @param {Number} ttl number of hours, the sandbox will live (if absent the realm default ttl is used)
      * @param {String} profile resource profile used (if absent "medium" is used)
      * @param {Boolean} autoScheduled sets the sandbox as auto scheduled (false by default)
+     * @param {String} startScheduler start schedule for the sandbox
+     * @param {String} stopScheduler stop schedule for the sandbox
      * @param {String} ocapiSettings additional ocapi settings
      * @param {String} webdavPermissions additional webdav permissions
      * @param {Boolean} asJson optional flag to force output in json, false by default
      * @param {Boolean} sync whether to operate in synchronous mode, false by default
      * * @param {Boolean} setAsDefault optional flag to set as new default instance, false by default
      */
-    create : function(realm, alias, ttl, profile, autoScheduled, ocapiSettings, webdavPermissions, asJson, sync,
-        setAsDefault) {
+    create: function (realm, alias, ttl, profile, autoScheduled, startScheduler, stopScheduler,
+        ocapiSettings, webdavPermissions, asJson, sync, setAsDefault) {
         // memorize the start time and duration
         var startTime = Date.now();
         var duration = 0;
 
-        createSandbox(realm, ttl, profile, autoScheduled, ocapiSettings, webdavPermissions, function(err, newSandbox) {
-            if (err) {
-                if (asJson) {
-                    console.json({error: err.message});
-                } else {
-                    console.error(err.message);
-                }
-                return;
-            }
-
-            // the result
-            var result = {
-                message : util.format('Creation of new sandbox %s for realm %s triggered and ongoing. ' +
-                    'Sandbox id is %s, status of sandbox is %s. You may use `sfcc-ci sandbox:list` to ' +
-                    'check the status of the sandbox.', newSandbox.instance, newSandbox.realm, newSandbox.id,
-                newSandbox.state),
-                sandbox : newSandbox };
-
-            // add to list of instances and use alias, if passed
-            var newHost = newSandbox.hostName;
-            // use <realm>-<instance> as standard alias
-            var newAlias = newSandbox.realm + '-' + newSandbox.instance;
-            // ...or use passed alias
-            if ( alias ) {
-                newAlias = alias;
-            }
-            instance.addInstance(newHost, newAlias);
-
-            // append to result
-            result['instance'] = { host: newHost, alias: newAlias, default: false };
-            result['message'] += util.format(' New sandbox host %s added to list of instances using alias "%s".',
-                newHost, newAlias);
-
-            // set new sandbox as default instance using alias, if passed
-            if ( setAsDefault ) {
-                instance.config.setDefault(newHost, function(err) {
-                    if (!err) {
-                        result['instance']['default'] = true;
-                        result['message'] += ' New sandbox set as default instance.';
+        createSandbox(realm, ttl, profile, autoScheduled, startScheduler, stopScheduler,
+            ocapiSettings, webdavPermissions, function (err, newSandbox) {
+                if (err) {
+                    if (asJson) {
+                        console.json({error: err.message});
                     } else {
-                        result['warning'] = err.message;
+                        console.error(err.message);
                     }
-                });
-            } else if ( instance.getAllInstances().length === 1 && !instance.config.getDefault() ) {
-                // set as default, if its the first instance and no default set yet
-                instance.config.setDefault(newHost, function(err) {
-                    if (!err) {
-                        result['instance']['default'] = true;
-                        result['message'] += ' New sandbox set as default instance.';
-                    } else {
-                        result['warning'] = err.message;
-                    }
-                });
-            }
-
-            // in async mode, just return the result of the triggering
-            if (!sync) {
-                if (asJson) {
-                    console.json(result);
-                } else {
-                    console.info(result['message']);
-                    if (result['warning']) {
-                        console.warn(result['warning']);
-                    }
+                    return;
                 }
-                return;
-            }
 
-            // in sync mode, read the details of the sandbox we have just triggered creation for
+                // the result
+                var result = {
+                    message: util.format('Creation of new sandbox %s for realm %s triggered and ongoing. ' +
+                        'Sandbox id is %s, status of sandbox is %s. You may use `sfcc-ci sandbox:list` to ' +
+                        'check the status of the sandbox.', newSandbox.instance, newSandbox.realm, newSandbox.id,
+                    newSandbox.state),
+                    sandbox: newSandbox
+                };
 
-            // no failure
-            var finished = false;
-            var fault = null;
+                // add to list of instances and use alias, if passed
+                var newHost = newSandbox.hostName;
+                // use <realm>-<instance> as standard alias
+                var newAlias = newSandbox.realm + '-' + newSandbox.instance;
+                // ...or use passed alias
+                if (alias) {
+                    newAlias = alias;
+                }
+                instance.addInstance(newHost, newAlias);
 
-            // error threshold
-            var errorThreshold = SANDBOX_STATUS_POLL_ERROR_THRESHOLD;
+                // append to result
+                result['instance'] = {host: newHost, alias: newAlias, default: false};
+                result['message'] += util.format(' New sandbox host %s added to list of instances using alias "%s".',
+                    newHost, newAlias);
 
-            // monitor creation and status updates until either status of new sandbox is started or operation
-            // timeout has been reached
-            var timeout = setInterval(function() {
-                // poll the status
-                getSandbox(newSandbox.id, null, function(err, sandbox) {
-                    // check if operation timeout has been exceeded
-                    if ( Date.now() - startTime > getSandboxAPIPollingTimeout() ) {
-                        // report an exceeded operation timeout
-                        fault = {
-                            message : 'Sandbox creation timeout has been exceeded.'
-                        };
-                    } else if (err && errorThreshold > 0) {
-                        // in case status retrieval failed
-                        // decrease the error threshold
-                        errorThreshold--;
-                        // don't set an error and allow the polling to continue
-                        console.debug('Polling sandbox status failed. Polling error threshold not reached.');
-                    } else if (err && errorThreshold === 0) {
-                        // report a reached error threshold during polling
-                        fault = {
-                            message : 'Polling sandbox status failed. Error threshold reached. Stop polling, ' +
-                                'the creation may still continue. Detailed error was ' + err.message
-                        };
-                    } else if (!err) {
-                        // status retrieved
-                        // update the status
-                        //newSandbox = sandbox;
-                        result['sandbox'] = sandbox;
-                        if (sandbox && sandbox.state === SANDBOX_STATUS_UP_AND_RUNNING ) {
-                            finished = true;
-                        } else if (sandbox && sandbox.state === SANDBOX_STATUS_FAILED ) {
-                            // report a failed sandbox
-                            fault = {
-                                message : 'Sandbox creation resulted in sandbox of status `failed`'
-                            };
+                // set new sandbox as default instance using alias, if passed
+                if (setAsDefault) {
+                    instance.config.setDefault(newHost, function (err) {
+                        if (!err) {
+                            result['instance']['default'] = true;
+                            result['message'] += ' New sandbox set as default instance.';
+                        } else {
+                            result['warning'] = err.message;
+                        }
+                    });
+                } else if (instance.getAllInstances().length === 1 && !instance.config.getDefault()) {
+                    // set as default, if its the first instance and no default set yet
+                    instance.config.setDefault(newHost, function (err) {
+                        if (!err) {
+                            result['instance']['default'] = true;
+                            result['message'] += ' New sandbox set as default instance.';
+                        } else {
+                            result['warning'] = err.message;
+                        }
+                    });
+                }
+
+                // in async mode, just return the result of the triggering
+                if (!sync) {
+                    if (asJson) {
+                        console.json(result);
+                    } else {
+                        console.info(result['message']);
+                        if (result['warning']) {
+                            console.warn(result['warning']);
                         }
                     }
+                    return;
+                }
 
-                    if (!finished && !fault) {
-                        // continue polling
-                        return;
-                    }
+                // in sync mode, read the details of the sandbox we have just triggered creation for
 
-                    // update duration
-                    duration = Date.now() - startTime;
-                    // skip polling
-                    clearInterval(timeout);
+                // no failure
+                var finished = false;
+                var fault = null;
 
-                    if (fault) {
-                        // the sandbox creation was triggered, but the polling failed or sandbox state is failed
-                        // treat this as error
-                        result['error'] = fault.message;
-                    } else {
-                        // TODO append message (e.g. from default set)
-                        result['message'] = util.format('Creation of new sandbox %s for realm %s finished (%s ms). ' +
-                            'Sandbox id is %s, status of sandbox is %s. You may use `sfcc-ci sandbox:list` to ' +
-                            'check the status of the sandbox.', result['sandbox'].instance, result['sandbox'].realm,
-                        duration, result['sandbox'].id, result['sandbox'].state);
-                    }
+                // error threshold
+                var errorThreshold = SANDBOX_STATUS_POLL_ERROR_THRESHOLD;
 
-                    // format output as JSON if needed
-                    if ( asJson ) {
-                        console.json(result);
-                        return;
-                    }
+                // monitor creation and status updates until either status of new sandbox is started or operation
+                // timeout has been reached
+                var timeout = setInterval(function () {
+                    // poll the status
+                    getSandbox(newSandbox.id, null, function (err, sandbox) {
+                        // check if operation timeout has been exceeded
+                        if (Date.now() - startTime > getSandboxAPIPollingTimeout()) {
+                            // report an exceeded operation timeout
+                            fault = {
+                                message: 'Sandbox creation timeout has been exceeded.'
+                            };
+                        } else if (err && errorThreshold > 0) {
+                            // in case status retrieval failed
+                            // decrease the error threshold
+                            errorThreshold--;
+                            // don't set an error and allow the polling to continue
+                            console.debug('Polling sandbox status failed. Polling error threshold not reached.');
+                        } else if (err && errorThreshold === 0) {
+                            // report a reached error threshold during polling
+                            fault = {
+                                message: 'Polling sandbox status failed. Error threshold reached. Stop polling, ' +
+                                    'the creation may still continue. Detailed error was ' + err.message
+                            };
+                        } else if (!err) {
+                            // status retrieved
+                            // update the status
+                            //newSandbox = sandbox;
+                            result['sandbox'] = sandbox;
+                            if (sandbox && sandbox.state === SANDBOX_STATUS_UP_AND_RUNNING) {
+                                finished = true;
+                            } else if (sandbox && sandbox.state === SANDBOX_STATUS_FAILED) {
+                                // report a failed sandbox
+                                fault = {
+                                    message: 'Sandbox creation resulted in sandbox of status `failed`'
+                                };
+                            }
+                        }
 
-                    // plain output
-                    console.info(result['message']);
-                    if (result['warning']) {
-                        console.warn(result['warning']);
-                    }
-                    if (result['error']) {
-                        console.error(result['error']);
-                    }
-                });
-            }, SANDBOX_STATUS_POLL_TIMEOUT);
-        });
+                        if (!finished && !fault) {
+                            // continue polling
+                            return;
+                        }
+
+                        // update duration
+                        duration = Date.now() - startTime;
+                        // skip polling
+                        clearInterval(timeout);
+
+                        if (fault) {
+                            // the sandbox creation was triggered, but the polling failed or sandbox state is failed
+                            // treat this as error
+                            result['error'] = fault.message;
+                        } else {
+                            // TODO append message (e.g. from default set)
+                            result['message'] = util.format('Creation of new sandbox %s for realm %s ' +
+                                'finished (%s ms). Sandbox id is %s, status of sandbox is %s. You may use ' +
+                                '`sfcc-ci sandbox:list` to check the status of the sandbox.',
+                            result['sandbox'].instance, result['sandbox'].realm, duration,
+                            result['sandbox'].id, result['sandbox'].state);
+                        }
+
+                        // format output as JSON if needed
+                        if (asJson) {
+                            console.json(result);
+                            return;
+                        }
+
+                        // plain output
+                        console.info(result['message']);
+                        if (result['warning']) {
+                            console.warn(result['warning']);
+                        }
+                        if (result['error']) {
+                            console.error(result['error']);
+                        }
+                    });
+                }, SANDBOX_STATUS_POLL_TIMEOUT);
+            });
     },
 
     /**
@@ -1563,9 +1610,11 @@ module.exports.cli = {
      * @param {String} spec specification of the sandbox to update
      * @param {Number} ttl number of hours, the sandbox TTL will be prolonged
      * @param {Boolean} autoScheduled sets the sandbox as auto scheduled
+     * @param {String} startScheduler start schedule for the sandbox
+     * @param {String} stopScheduler stop schedule for the sandbox
      * @param {Boolean} asJson optional flag to force output in json, false by default
      */
-    update : function(spec, ttl, autoScheduled, asJson) {
+    update : function(spec, ttl, autoScheduled, startScheduler, stopScheduler, asJson) {
         // sandbox to update
         var foundSandbox = null;
 
@@ -1592,21 +1641,22 @@ module.exports.cli = {
                 return;
             } else {
                 // sandbox found, trigger operation
-                updateSandbox(foundSandbox.id, ttl, autoScheduled, function(err, updatedSandbox) {
-                    var result = {};
-                    if (err) {
-                        result['error'] = err.message;
-                    } else {
-                        result = updatedSandbox;
-                    }
-                    if (asJson) {
-                        console.json(result);
-                    } else if (err) {
-                        console.error(err.message);
-                    } else {
-                        console.prettyPrint(result);
-                    }
-                });
+                updateSandbox(foundSandbox.id, ttl, autoScheduled, startScheduler, stopScheduler,
+                    function(err, updatedSandbox) {
+                        var result = {};
+                        if (err) {
+                            result['error'] = err.message;
+                        } else {
+                            result = updatedSandbox;
+                        }
+                        if (asJson) {
+                            console.json(result);
+                        } else if (err) {
+                            console.error(err.message);
+                        } else {
+                            console.prettyPrint(result);
+                        }
+                    });
             }
         });
     },


### PR DESCRIPTION
This change is to add scheduler to the sfcc-ci. The schedule to start and stop a sandbox is an existing functionality for a Realm. We have added a new functionality to mange the schedule per Sandbox as well. 