### PR TITLE
[FEATURE] allow grant type to be specified for client:auth

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -77,11 +77,11 @@ program
     .option('-a, --authserver [authserver]','The authorization server used to authenticate')
     .option('-r, --renew','Controls whether the authentication should be automatically renewed, ' +
         'once the token expires.')
-    .option('-t, --granttype [granttype]','The grant type to use (password or client_credentials)')
+    .option('-t, --type [type]','The grant type to use (password or client_credentials)')
     .description('Authenticate an API client with an optional user for automation use')
     .action(function(client, secret, user, user_password, options) {
         var renew = ( options.renew ? options.renew : false );
-        var grantType = ( options.granttype === 'client_credentials' ? 'client_credentials' : 'password' );
+        var grantType = ( options.type === 'client_credentials' ? 'client_credentials' : 'password' );
         require('./lib/auth').auth(client, secret, user, user_password, renew, options.authserver, grantType);
     }).on('--help', function() {
         console.log('');

--- a/cli.js
+++ b/cli.js
@@ -105,6 +105,7 @@ program
         console.log('    $ sfcc-ci client:auth my_client_id my_client_secret');
         console.log('    $ sfcc-ci client:auth my_client_id my_client_secret -r');
         console.log('    $ sfcc-ci client:auth my_client_id my_client_secret -a account.demandware.com');
+        console.log('    $ sfcc-ci client:auth my_client_id my_client_secret -t client_credentials');
         console.log('    $ sfcc-ci client:auth');
         console.log();
     });

--- a/cli.js
+++ b/cli.js
@@ -77,10 +77,12 @@ program
     .option('-a, --authserver [authserver]','The authorization server used to authenticate')
     .option('-r, --renew','Controls whether the authentication should be automatically renewed, ' +
         'once the token expires.')
+    .option('-t, --granttype [granttype]','The grant type to use (password or client_credentials)')
     .description('Authenticate an API client with an optional user for automation use')
     .action(function(client, secret, user, user_password, options) {
         var renew = ( options.renew ? options.renew : false );
-        require('./lib/auth').auth(client, secret, user, user_password, renew, options.authserver);
+        var grantType = ( options.granttype === 'client_credentials' ? 'client_credentials' : 'password' );
+        require('./lib/auth').auth(client, secret, user, user_password, renew, options.authserver, grantType);
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -1793,14 +1795,14 @@ program
         console.log();
         console.log('  Examples:');
         console.log();
-        console.log('    $ sfcc-ci code:diffdeploy "newcodeversion" "/path/to/repo1,/path/to/repo2"');
-        console.log('    $ sfcc-ci code:diffdeploy "newcodeversion" "/path/to/repo1,/path/to/repo2" ' +
+        console.log('    $ sfcc-ci code:deploy:diff "newcodeversion" "/path/to/repo1,/path/to/repo2"');
+        console.log('    $ sfcc-ci code:deploy:diff "newcodeversion" "/path/to/repo1,/path/to/repo2" ' +
             '-i my-instance-alias');
-        console.log('    $ sfcc-ci code:diffdeploy "newcodeversion" "/path/to/repo1,/path/to/repo2" ' +
+        console.log('    $ sfcc-ci code:deploy:diff "newcodeversion" "/path/to/repo1,/path/to/repo2" ' +
             '-i my-instance.demandware.net');
-        console.log('    $ sfcc-ci code:diffdeploy "newcodeversion" "/path/to/repo1,/path/to/repo2" ' +
+        console.log('    $ sfcc-ci code:deploy:diff "newcodeversion" "/path/to/repo1,/path/to/repo2" ' +
             '-i my-instance.demandware.net -a');
-        console.log('    $ sfcc-ci code:diffdeploy "newcodeversion" "/path/to/repo1,/path/to/repo2" ' +
+        console.log('    $ sfcc-ci code:deploy:diff "newcodeversion" "/path/to/repo1,/path/to/repo2" ' +
             '-i my-instance.demandware.net -a -c path/to/my/certificate.p12 -p "myPassphraseForTheCertificate"');
         console.log();
     });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -153,12 +153,18 @@ function obtainToken(accountManagerHostOverride, basicAuthUser, basicAuthPasswor
  * @param {String} clientSecret The client secret to use with the authentication flow
  * @param {String} user The user to use with the authentication flow
  * @param {String} userPassword The user password to use with the authentication flow
- * @param {Boolean} autoRenew A flag controlling, wether the access token should be renewed automatically, false by default
+ * @param {Boolean} autoRenew A flag controlling, whether the access token should be renewed automatically, false by default
  * @param {String} accountManager The optional host name of the Account Manager to use as authorization server
+ * @param {String} grantType Optional, the grant type to use. Force client_credentials if dw.json is present
  */
-function auth(client, clientSecret, user, userPassword, autoRenew, accountManager) {
+function auth(client, clientSecret, user, userPassword, autoRenew, accountManager, grantType) {
+    var flows = {
+        password: { grant : 'password', response_type : 'code' },
+        client_credentials: { grant : 'client_credentials', response_type : 'token' }
+    }
+
     // determine oauth flow to use, by default it is resource owner password credentials
-    var flow = { grant : 'password', response_type : 'code' };
+    var flow = flows[grantType];
 
     // if client and secret are not passed, attempt to look them up from alternative sources, honoring dw.json and env vars
     if ( !client && !clientSecret ) {
@@ -177,7 +183,7 @@ function auth(client, clientSecret, user, userPassword, autoRenew, accountManage
             user = secrets.getUsername(null);
             userPassword = secrets.getPassword(null);
         } catch (e) {
-            // in case lookup fails and user credentails are not present, we still want to support client_credentials grant
+            // in case lookup fails and user credentials are not present, we still want to support client_credentials grant
         }
     }
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -157,7 +157,7 @@ function obtainToken(accountManagerHostOverride, basicAuthUser, basicAuthPasswor
  * @param {String} accountManager The optional host name of the Account Manager to use as authorization server
  * @param {String} grantType Optional, the grant type to use. Force client_credentials if dw.json is present
  */
-function auth(client, clientSecret, user, userPassword, autoRenew, accountManager, grantType) {
+function auth(client, clientSecret, user, userPassword, autoRenew, accountManager, grantType = 'password') {
     var flows = {
         password: { grant : 'password', response_type : 'code' },
         client_credentials: { grant : 'client_credentials', response_type : 'token' }

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -145,6 +145,19 @@ describe('Tests for lib/auth.js', function() {
                 const postArgs = requestStub.post.getCall(0).args[0];
                 expect(postArgs.uri).to.equal('https://account-pod5.demandware.net/dw/oauth2/access_token');
             });
+
+            it('use password grant type if no grantType param is provided', function() {
+                auth.auth(clientKey, clientSecret, user, password);
+                const postArgs = requestStub.post.getCall(0).args[0];
+                expect(postArgs.form.grant_type).to.equal('password');
+            });
+
+            it('use client_credentials grant type if grantType param is provided', function() {
+                const grantType = 'client_credentials';
+                auth.auth(clientKey, clientSecret, user, password, false, null, grantType);
+                const postArgs = requestStub.post.getCall(0).args[0];
+                expect(postArgs.form.grant_type).to.equal('client_credentials');
+            });
         });
     });
 


### PR DESCRIPTION
closes #245

I do not see this as a breaking change because everything will continue to work normally but we have a new option that will allow you to force client_credentials grant type

Related to [Resource Owner Password Credentials Authentication Failure](https://github.com/SalesforceCommerceCloud/sfcc-ci/wiki/Resource-Owner-Password-Credentials-Authentication-Failure)

**What PR adjusts**:
Allows grant type to be specified for `client:auth`. For example: `sfcc-ci  client:auth -t client_credentials`. Default grant type will remain unchanged and is set to `password` by default.

**Why?**
I'm running a local project where I'm running into the `Error: Authentication failed: Resource owner authentication failed` mentioned in the related doc above. Because I have a `dw.json` file in my project, the grant type of `password` is always being used.  Due to my Account Manager setup, this is throwing an error. If I force the grant type of `client_credentials`, everything works as expected because I've added the necessary permissions to my client.