### PR TITLE
Add request letsencrypt certificate

### DIFF
--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -854,6 +854,33 @@ else
 	exit 1
 fi
 
+echo "Testing command ´sfcc-ci sandbox:alias:add´ with request for letsencrypt:"
+ALIAS_RESULT=`node ./cli.js sandbox:alias:add --sandbox $TEST_NEW_SANDBOX_ID -h my.newalias.com --unique true --request-letsencrypt-certificate true --json`
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
+echo "Testing command ´sfcc-ci sandbox:alias:add´ with request for letsencrypt and unique as false :"
+ALIAS_RESULT=`node ./cli.js sandbox:alias:add --sandbox $TEST_NEW_SANDBOX_ID -h my.newalias.com --unique false --request-letsencrypt-certificate true --json`
+if [ $? -eq 1 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
+
+TEST_NEW_ALIAS_ID=`echo $ALIAS_RESULT | jq '.id' -r`
+echo "Testing command ´sfcc-ci sandbox:alias:delete´ (invalid alias):"
+node ./cli.js sandbox:alias:delete --sandbox $TEST_NEW_SANDBOX_ID -a $TEST_NEW_ALIAS_ID --noprompt
+if [ $? -eq 0 ]; then
+    echo -e "\t> OK"
+else
+	echo -e "\t> FAILED"
+	exit 1
+fi
 ###############################################################################
 ###### Testing ´sfcc-ci instance:clear´
 ###############################################################################

--- a/bin/test-cli.sh
+++ b/bin/test-cli.sh
@@ -855,7 +855,7 @@ else
 fi
 
 echo "Testing command ´sfcc-ci sandbox:alias:add´ with request for letsencrypt:"
-ALIAS_RESULT=`node ./cli.js sandbox:alias:add --sandbox $TEST_NEW_SANDBOX_ID -h my.newalias.com --unique true --request-letsencrypt-certificate true --json`
+ALIAS_RESULT=`node ./cli.js sandbox:alias:add --sandbox $TEST_NEW_SANDBOX_ID -h my.newalias.com --unique  --request-letsencrypt-certificate  --json`
 if [ $? -eq 0 ]; then
     echo -e "\t> OK"
 else
@@ -863,8 +863,8 @@ else
 	exit 1
 fi
 
-echo "Testing command ´sfcc-ci sandbox:alias:add´ with request for letsencrypt and unique as false :"
-ALIAS_RESULT=`node ./cli.js sandbox:alias:add --sandbox $TEST_NEW_SANDBOX_ID -h my.newalias.com --unique false --request-letsencrypt-certificate true --json`
+echo "Testing command ´sfcc-ci sandbox:alias:add´ with request for letsencrypt and unique as false ( should fail ) :"
+ALIAS_RESULT=`node ./cli.js sandbox:alias:add --sandbox $TEST_NEW_SANDBOX_ID -h my.newalias.com  --request-letsencrypt-certificate --json`
 if [ $? -eq 1 ]; then
     echo -e "\t> OK"
 else

--- a/cli.js
+++ b/cli.js
@@ -1047,7 +1047,7 @@ program
     .option('-h, --host <host>','hostname alias to register')
     .option('-j, --json', 'Optional, formats the output in json')
     .option('-u, --unique', 'Optional, define alias as unique, false by default')
-    .option('-l, --request-letsencrypt-certificate <requestLetsncrypt>', 'Optional, ' +
+    .option('-l, --request-letsencrypt-certificate', 'Optional, ' +
         'Request Letsencrypt certificate, false by default')
     .description('Registers a hostname alias for a sandbox.')
     .action(function(options) {
@@ -1073,9 +1073,11 @@ program
         }
         var asJson = ( options.json ? options.json : false );
         var unique = ( options.unique ? options.unique : false );
-        var requestLetsncrypt = ( options.requestLetsncrypt ? options.requestLetsncrypt : false );
-        if (requestLetsncrypt && !unique) {
-            this.missingArgument(unique)
+        var requestLetsncrypt =
+            ( options.requestLetsencryptCertificate ? options.requestLetsencryptCertificate : false );
+        if (requestLetsncrypt === true && unique === false) {
+            this.missingArgument('unique');
+            return;
         }
         require('./lib/sandbox').cli.alias.create(spec, aliasName, unique, asJson, requestLetsncrypt);
     }).on('--help', function() {

--- a/cli.js
+++ b/cli.js
@@ -1090,10 +1090,12 @@ program
         console.log('  Use the --unique flag allows you to configure the alias to be unique across all aliases');
         console.log('  registered. This requires that you have to proof ownership of the host on a DNS level.');
         console.log('  The domain verification record value is generated and returned. By default the alias is not');
-        console.log('  unique. If requesting for a Letsencrypt certificate, this needs to be true');
+        console.log('  unique. If requesting for a Letsencrypt certificate, this flag needs to be true');
         console.log('');
-        console.log('  Use the --request-letsencrypt-certificate flag allows you request for a Letsencrypt ');
-        console.log('  certificate. You have to specify --unique flag as true to enable this.');
+        console.log('  Use the --request-letsencrypt-certificate flag allows you to request a valid certificate ');
+        console.log('  to be generated on the fly through Lets Encrypt. This action consumes certificate requests ');
+        console.log('  from the domain quota imposed by Let\'s Encrypt, please read the Alias documentation ');
+        console.log('  carefully. You have to specify --unique flag as true when you enable this flag.');
         console.log('');
         console.log('  Use --json to only print the created alias incl. either the registration link or the');
         console.log('  the domain verification record.');

--- a/cli.js
+++ b/cli.js
@@ -1094,7 +1094,7 @@ program
         console.log('');
         console.log('  Use the --request-letsencrypt-certificate flag allows you to request a valid certificate ');
         console.log('  to be generated on the fly through Lets Encrypt. This action consumes certificate requests ');
-        console.log('  from the domain quota imposed by Let\'s Encrypt, please read the Alias documentation ');
+        console.log('  from the domain quota imposed by Lets Encrypt, please read the Alias documentation ');
         console.log('  carefully. You have to specify --unique flag as true when you enable this flag.');
         console.log('');
         console.log('  Use --json to only print the created alias incl. either the registration link or the');

--- a/cli.js
+++ b/cli.js
@@ -1047,6 +1047,8 @@ program
     .option('-h, --host <host>','hostname alias to register')
     .option('-j, --json', 'Optional, formats the output in json')
     .option('-u, --unique', 'Optional, define alias as unique, false by default')
+    .option('-l, --request-letsencrypt-certificate <requestLetsncrypt>', 'Optional, ' +
+        'Request Letsencrypt certificate, false by default')
     .description('Registers a hostname alias for a sandbox.')
     .action(function(options) {
         var sandbox = options.sandbox;
@@ -1071,7 +1073,11 @@ program
         }
         var asJson = ( options.json ? options.json : false );
         var unique = ( options.unique ? options.unique : false );
-        require('./lib/sandbox').cli.alias.create(spec, aliasName, unique, asJson);
+        var requestLetsncrypt = ( options.requestLetsncrypt ? options.requestLetsncrypt : false );
+        if (requestLetsncrypt && !unique) {
+            this.missingArgument(unique)
+        }
+        require('./lib/sandbox').cli.alias.create(spec, aliasName, unique, asJson, requestLetsncrypt);
     }).on('--help', function() {
         console.log('');
         console.log('  Details:');
@@ -1084,7 +1090,10 @@ program
         console.log('  Use the --unique flag allows you to configure the alias to be unique across all aliases');
         console.log('  registered. This requires that you have to proof ownership of the host on a DNS level.');
         console.log('  The domain verification record value is generated and returned. By default the alias is not');
-        console.log('  unique.');
+        console.log('  unique. If requesting for a Letsencrypt certificate, this needs to be true');
+        console.log('');
+        console.log('  Use the --request-letsencrypt-certificate flag allows you request for a Letsencrypt ');
+        console.log('  certificate. You have to specify --unique flag as true to enable this.');
         console.log('');
         console.log('  Use --json to only print the created alias incl. either the registration link or the');
         console.log('  the domain verification record.');
@@ -1093,6 +1102,7 @@ program
         console.log();
         console.log('    $ sfcc-ci sandbox:alias:add -s my-sandbox-id -h sbx1.merchant.com');
         console.log('    $ sfcc-ci sandbox:alias:add -s my-sandbox-id -h sbx1.merchant.com -j');
+        console.log('    $ sfcc-ci sandbox:alias:add -s my-sandbox-id -h sbx1.merchant.com -u true -l true -j');
         console.log();
     });
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -782,12 +782,13 @@ function doCookieRegistration(realm, link, host) {
  * @param sbxID ID of the sandbox to create alias for
  * @param alias name of the alias to create
  * @param unique true, if the alias is unique across aliases, false by default
+ * @param requestLetsncrypt true, if need to request for Letsencrypt certificate, false by default
  * @param {Function} callback the callback to execute, the error and the created alias are available as arguments to the callback function
  */
-function registerForSandbox(sbxID, alias, unique, callback) {
+function registerForSandbox(sbxID, alias, unique, requestLetsncrypt, callback) {
     // the payload
     var options = ocapi.getOptions('POST', API_SANDBOXES + '/' + sbxID + '/aliases');
-    options['body'] = {name: alias, unique: !!unique};
+    options['body'] = {name: alias, unique: !!unique, requestLetsEncryptCertificate : !!requestLetsncrypt};
 
     ocapi.retryableCall('POST', options, function (err, res) {
         if (err) {
@@ -1669,10 +1670,11 @@ module.exports.cli = {
          * @param {String} alias the alias name to register for the sandbox
          * @param {Boolean} unique optional flag to configure the alias to be unique, false by default
          * @param {Boolean} asJson optional flag to force output in json, false by default
+         * @param {Boolean} requestLetsncrypt optional flag to request a new certificate, false by default
          */
-        create : function (spec, alias, unique, asJson) {
+        create : function (spec, alias, unique, asJson, requestLetsncrypt) {
             runForSandbox(spec, asJson, function (sandbox) {
-                registerForSandbox(sandbox.id, alias, unique, function (err, result) {
+                registerForSandbox(sandbox.id, alias, unique, requestLetsncrypt, function (err, result) {
                     if (err) {
                         if (asJson) {
                             console.json({error: err.message});

--- a/test/unit/sandbox.js
+++ b/test/unit/sandbox.js
@@ -96,6 +96,10 @@ describe('Alias Tests for lib/sandbox.js', function() {
                     responseHandler("Alias not found.", {statusCode: 404, body: {}});
                     return
                 }
+                if (url.includes('nonUniqueAlias')) {
+                    responseHandler("Can not request certificate for a non-unique alias.", {statusCode: 409, body: {}});
+                    return
+                }
                 if (url.endsWith('/aliases')) {
                     if (method === 'GET') {
                         responseHandler("", {statusCode: 200, body: aliasList});
@@ -167,6 +171,10 @@ describe('Alias Tests for lib/sandbox.js', function() {
             sinon.assert.calledWith(consJson, {error: "Cannot find sandbox with given ID."});
             sandbox.cli.alias.create({id: "unknownSandboxId"},"alias", false, false);
             sinon.assert.calledWith(consError, "Cannot find sandbox with given ID.");
+        });
+        it('Create SBX alias with cert request', () => {
+            sandbox.cli.alias.create({id: "s1"},"alias", false, true, true);
+            sinon.assert.calledWith(consJson, existingAlias.data);
         });
     })
 


### PR DESCRIPTION
Adds support for request of a Let's Encrypt certificate through the sandbox alias creation as new flag `-,--request-letsencrypt-certificate` to command `sfcc-ci sandbox:alias:create`
> Request a valid certificate to be generated on the fly through Lets Encrypt. This action consumes certificate requests from the domain quota imposed by Let's Encrypt, please read the Alias documentation carefully.