### PR TITLE
Multiple sandboxes found - Execute operation for first only

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -515,7 +515,25 @@ function lookupSandbox(spec, callback) {
             return;
         }
 
-        callback(new Error('Found ' + filtered.length + ' matching sandboxes.'));
+        // multiple sandboxes should be the very exception and in those cases the most recently created
+        // sandbox should be addressed with the requested operation. in all other cases the operation should
+        // be skipped and error messages returned.
+        filtered = filtered.sort( function sortFilteredSandboxesDesc(sb1, sb2) {
+            return sb1.createdAt.localeCompare(sb2.createdAt) * -1;
+        });
+
+        var sandboxIndex = 1;
+        filtered.forEach( function(sbxInfo) {
+            if (sandboxIndex === 1) {
+                console.warn('More than one sandbox found. Executing the operation only for '
+                + 'the sandbox tha has been created on ' + sbxInfo.createdAt);
+                callback(undefined , sbxInfo);
+            } else {
+                callback(new Error('Ambigious sandbox ID. Skipping operation for the sandbox that has '
+                    + 'been created on ' + sbxInfo.createdAt));
+            }
+            sandboxIndex++;
+        });
     });
 }
 


### PR DESCRIPTION
The fix sorts all sandboxes by creation date (latest on top), calls out a warning on the first sandbox but executes the operation anyway and throws an error for subsequent sandboxes.