### PR TITLE
#577 fix scheduler param order

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -796,7 +796,7 @@ program
             }
         }
         if (scheduleOk) {
-            require('./lib/sandbox').cli.update(spec, ttl, autoScheduled, false, startScheduler, stopScheduler);
+            require('./lib/sandbox').cli.update(spec, ttl, autoScheduled, startScheduler, stopScheduler, false);
         }
     }).on('--help', function() {
         console.log('');


### PR DESCRIPTION
the sandbox:update logic calls update() with the wrong order of parameters so that stopScheduler is always null... this corrects that