### PR TITLE
handle support/internal user requirements for system jobs

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -60,6 +60,25 @@ function run(instance, job_id, request_doc, asJson) {
             // in case of errors
             var result = { error : util.format('Starting job "%s" on %s failed',
                 job_id, instance), fault : res.body.fault };
+
+            // handle case of res.body.fault.type === 'UnknownPropertyException'
+            // this must be a support user, so we need to re-run with normal job parameters form
+            if (job_id === 'sfcc-site-archive-import' && request_doc.file_name && 
+                res.body.fault && res.body.fault.type === 'UnknownPropertyException') {
+
+              console.warn("internal users must use different form for import; re-running job")
+
+              return run(instance, job_id, {
+                parameters: [
+                  {
+                    name: "ImportFile",
+                    value: request_doc.file_name
+                  }
+                ]
+              }, asJson);
+            }
+            // TODO handle export as well
+
             if (asJson) {
                 console.json(result);
             } else {
@@ -160,6 +179,24 @@ function runSync(instance, job_id, request_doc, asJson, failFast) {
             // in case of errors
             var result = { error : util.format('Starting job "%s" on %s failed',
                 job_id, instance), fault : res.body.fault };
+
+            // handle case of res.body.fault.type === 'UnknownPropertyException'
+            // this must be a support user, so we need to re-run with normal job parameters form
+            if (job_id === 'sfcc-site-archive-import' && request_doc.file_name && 
+                res.body.fault && res.body.fault.type === 'UnknownPropertyException') {
+
+              console.warn("internal users must use different form for import; re-running job")
+
+              return run(instance, job_id, {
+                parameters: [
+                  {
+                    name: "ImportFile",
+                    value: request_doc.file_name
+                  }
+                ]
+              }, asJson);
+            }
+
             if (asJson) {
                 console.json(result);
             } else {


### PR DESCRIPTION
- internal SF support users must call OCAPI system jobs using the normal job calling convention and not the special syntax
- check if the error indicates we are in this situation and re-run with rewritten params