### PR TITLE
Recommend b2c-cli to customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+> [!WARNING]
+> ## This project is deprecated
+>
+> **sfcc-ci** is no longer actively maintained. Please use **[@salesforce/b2c-cli](https://www.npmjs.com/package/@salesforce/b2c-cli)** instead.
+>
+> **Install:**
+> ```
+> npm install -g @salesforce/b2c-cli
+> ```
+>
+> For migration details, see the [sfcc-ci Migration Guide](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/sfcc-ci-migration.html).
+
+---
+
 # Salesforce Commerce Cloud CLI #
 
 The Salesforce Commerce Cloud CLI is a command line interface (CLI) for Salesforce Commerce Cloud. It can be used to facilitate deployment and continuous integration practices using Salesforce B2C Commerce.

--- a/cli.js
+++ b/cli.js
@@ -13,17 +13,17 @@ var log = require('./lib/log');
 
 // Deprecation warning (skip in JSON mode to avoid polluting machine-readable output)
 if (!process.argv.includes('--json') && !process.argv.includes('-j')) {
-    process.stderr.write(
+    process.stderr.write(colors.yellow(
         '\n' +
-        colors.yellow('WARNING: sfcc-ci is deprecated and no longer actively maintained.\n') +
-        colors.yellow('Please migrate to @salesforce/b2c-cli:\n') +
+        'WARNING: sfcc-ci is deprecated and no longer actively maintained.\n' +
+        'Please migrate to @salesforce/b2c-cli:\n' +
         '\n' +
         '  npm install -g @salesforce/b2c-cli\n' +
         '\n' +
         'Migration guide:\n' +
         '  https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/sfcc-ci-migration.html\n' +
         '\n'
-    );
+    ));
 }
 
 program

--- a/cli.js
+++ b/cli.js
@@ -11,6 +11,20 @@ var { prompt } = require('inquirer');
 
 var log = require('./lib/log');
 
+// Deprecation warning (skip in JSON mode to avoid polluting machine-readable output)
+if (!process.argv.includes('--json') && !process.argv.includes('-j')) {
+    process.stderr.write(
+        '\n' +
+        colors.yellow('WARNING: sfcc-ci is deprecated and no longer actively maintained.\n') +
+        colors.yellow('Please migrate to @salesforce/b2c-cli:\n') +
+        '\n' +
+        '  npm install -g @salesforce/b2c-cli\n' +
+        '\n' +
+        'Migration guide:\n' +
+        '  https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/sfcc-ci-migration.html\n' +
+        '\n'
+    );
+}
 
 program
     .version(require('./package.json').version, '-V, --version')


### PR DESCRIPTION
We'd like the sfcc-ci users to migrate to the b2c-cli for the future. This adds a recommendation to the readme and CLI entry point to urge migration.

Omits any message on json mode.